### PR TITLE
修改tag搜寻方式

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListScene.java
@@ -984,9 +984,26 @@ public final class GalleryListScene extends BaseScene
                     ehTags = EhTagDatabase.getInstance(context);
                 }
                 //根据‘：’分割字符串为组名和标签名
-                String[] tags = text.split(":");
-
-                quickSearch.name = TagTranslationUtil.getTagCN(tags, ehTags);
+                //String[] tags = text.split(":");
+                //quickSearch.name = TagTranslationUtil.getTagCN(tags, ehTags);
+                String[] parts = text.split("(?=(?:(?:[^\"]*\"){2})*[^\"]*$)\\s+");
+                String newText = "";
+                for (int i = 0; i < parts.length; i++) {
+                    String[] tags = parts[i].split(":");
+                    for(int j=0; j<tags.length; j++)
+                    {
+                        tags[j]=tags[j].replace("\"", "").replace("$", "");
+                    }
+                    quickSearch.name = TagTranslationUtil.getTagCN(tags, ehTags);
+                    if(newText.isEmpty())
+                    {
+                        newText = TagTranslationUtil.getTagCN(tags, ehTags);
+                    }else
+                    {
+                        newText+=" "+TagTranslationUtil.getTagCN(tags, ehTags);
+                    }
+                }
+                quickSearch.name = newText;
             } else {
                 quickSearch.name = text;
             }

--- a/app/src/main/java/com/hippo/ehviewer/util/TagTranslationUtil.java
+++ b/app/src/main/java/com/hippo/ehviewer/util/TagTranslationUtil.java
@@ -13,6 +13,10 @@ public class TagTranslationUtil {
             String group = ehTags.getTranslation("n:" + tags[0]);
             //翻译标签名
             String prefix = EhTagDatabase.namespaceToPrefix(tags[0]);
+            if (tags[0].length() == 1 && tags[0].matches("^[a-z]+$")) {
+                prefix = tags[0] + ":";
+            }
+
             String tagStr = ehTags.getTranslation(prefix != null ? prefix + tags[1] : "" + tags[1]);
 
 
@@ -23,7 +27,10 @@ public class TagTranslationUtil {
             } else if (group == null && tagStr != null) {
                 return tags[0] + "：" + tagStr;
             } else {
-                return tags[0] + ":" + tags[1];
+                if(tagStr != null)
+                    return tags[0] + ":" + tagStr;
+                else
+                    return tags[0] + ":" + tags[1];
             }
         } else {
             StringBuffer s = new StringBuffer();


### PR DESCRIPTION
抱歉 pull功能不熟 重弄了几次(
1. 对于有带空格的tag 例如"ai generated"、"mind control"更容易搜寻
![螢幕擷取畫面 2023-11-02 170956](https://github.com/xiaojieonly/Ehviewer_CN_SXJ/assets/26001028/fb1efd48-7c6d-4558-a359-2b27dab6b036)
2. 修改对于增加快速搜寻标签时，若使用複數标签時未翻译的问题
![螢幕擷取畫面 2023-11-02 171039](https://github.com/xiaojieonly/Ehviewer_CN_SXJ/assets/26001028/7ce9e446-f58f-4681-9580-2f5fe7e00282)

希望能增加这个功能 
谢谢!