### PR TITLE
加速读取阅读进度执行速度

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/spider/SpiderQueen.java
+++ b/app/src/main/java/com/hippo/ehviewer/spider/SpiderQueen.java
@@ -205,6 +205,38 @@ public final class SpiderQueen implements Runnable {
     }
 
     @UiThread
+    public static int findStartPage(@NonNull Context context, @NonNull GalleryInfo galleryInfo) {
+        OSUtils.checkMainLoop();
+
+        SpiderInfo spiderInfo = null;
+        SimpleDiskCache msic;
+        EhApplication application = (EhApplication) context.getApplicationContext();
+        msic = EhApplication.getSpiderInfoCache(application);
+        InputStreamPipe pipe = msic.getInputStreamPipe(Long.toString(galleryInfo.gid));
+        if (null != pipe) {
+            try {
+                pipe.obtain();
+                spiderInfo = SpiderInfo.read(pipe.open());
+                if (spiderInfo != null && spiderInfo.gid == galleryInfo.gid &&
+                        spiderInfo.token.equals(galleryInfo.token)) {
+                }
+            } catch (IOException e) {
+                // Ignore
+            } finally {
+                pipe.close();
+                pipe.release();
+            }
+        }
+
+        int startPage = 0;
+        if (spiderInfo != null) {
+            startPage = spiderInfo.startPage;
+        } else {
+            startPage = 0;
+        }
+        return startPage;
+    }
+    @UiThread
     public static void releaseSpiderQueen(@NonNull SpiderQueen queen, @Mode int mode) {
         OSUtils.checkMainLoop();
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryAdapter.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryAdapter.java
@@ -43,6 +43,7 @@ import com.hippo.widget.recyclerview.AutoStaggeredGridLayoutManager;
 import com.hippo.yorozuya.ViewUtils;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import com.hippo.ehviewer.spider.SpiderQueen;
 
 abstract class GalleryAdapter extends RecyclerView.Adapter<GalleryHolder> {
 
@@ -208,7 +209,12 @@ abstract class GalleryAdapter extends RecyclerView.Adapter<GalleryHolder> {
                     holder.pages.setText(null);
                     holder.pages.setVisibility(View.GONE);
                 } else {
-                    holder.pages.setText(Integer.toString(gi.pages) + "P");
+                    int startPage = SpiderQueen.findStartPage(mInflater.getContext(), gi);
+                    if (startPage > 0) {
+                        holder.pages.setText(startPage + 1 + "/" + gi.pages + "P");
+                    } else {
+                        holder.pages.setText("0/" + gi.pages + "P");
+                    }
                     holder.pages.setVisibility(View.VISIBLE);
                 }
                 if (TextUtils.isEmpty(gi.simpleLanguage)) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryAdapterNew.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryAdapterNew.java
@@ -224,16 +224,12 @@ abstract class GalleryAdapterNew extends RecyclerView.Adapter<GalleryAdapterNew.
                     holder.pages.setText(null);
                     holder.pages.setVisibility(View.GONE);
                 } else {
-//                    会导致卡顿
-//                    SpiderQueen mSpiderQueen;
-//                    mSpiderQueen = SpiderQueen.obtainSpiderQueen(mInflater.getContext(), gi, SpiderQueen.MODE_READ);
-//                    if (mSpiderQueen.getStartPage() > 0) {
-//                        holder.pages.setText(mSpiderQueen.getStartPage() + 1 + "/" + gi.pages + "P");
-//                    } else {
-//                        holder.pages.setText("0/" + gi.pages + "P");
-//                    }
-//                    holder.pages.setVisibility(View.VISIBLE);
-                    holder.pages.setText(gi.pages + "P");
+                    int startPage = SpiderQueen.findStartPage(mInflater.getContext(), gi);
+                    if (startPage > 0) {
+                        holder.pages.setText(startPage + 1 + "/" + gi.pages + "P");
+                    } else {
+                        holder.pages.setText("0/" + gi.pages + "P");
+                    }
                     holder.pages.setVisibility(View.VISIBLE);
                 }
                 if (TextUtils.isEmpty(gi.simpleLanguage)) {


### PR DESCRIPTION
此修改将读取阅读进度执行时间由平均50ms提升至10ms以内
修正[#839](https://github.com/xiaojieonly/Ehviewer_CN_SXJ/pull/839)
