### PR TITLE
更新 DoH

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/EhDns.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhDns.java
@@ -83,20 +83,7 @@ public class EhDns implements Dns {
         hosts = EhApplication.getHosts(context);
         DnsOverHttps.Builder builder = new DnsOverHttps.Builder()
                 .client(new OkHttpClient.Builder().cache(EhApplication.getOkHttpCache(context)).build())
-                .url(HttpUrl.get("https://cloudflare-dns.com/dns-query"));
-        try {
-            builder.bootstrapDnsHosts(InetAddress.getByName("162.159.36.1"),
-                    InetAddress.getByName("162.159.46.1"),
-                    InetAddress.getByName("1.1.1.1"),
-                    InetAddress.getByName("1.0.0.1"),
-                    InetAddress.getByName("162.159.132.53"),
-                    InetAddress.getByName("2606:4700:4700::1111"),
-                    InetAddress.getByName("2606:4700:4700::1001"),
-                    InetAddress.getByName("2606:4700:4700::0064"),
-                    InetAddress.getByName("2606:4700:4700::6400"));
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-        }
+                .url(HttpUrl.get("https://77.88.8.1/dns-query"));
         dnsOverHttps = builder.post(true).build();
     }
 


### PR DESCRIPTION
@xiaojieonly 

1. 域名`cloudflare-dns.com`在未知时间被 GFW 封锁，猫耳逆变器在2021年3月就[移除](https://gitlab.com/NekoInverter/EhViewer/-/commit/63f2615980375f590b2e7d96a7f16eb899262877)了此SNI。
2. 鉴于 Cloudflare DNS 在国内部分地区连通性较差，更换为俄爹的 [Yandex DNS](https://dns.yandex.com/) 。

然后这样开启安全DNS后应该可以解决地区反诈劫持导致的 #980 #982 #983 等问题。