### PR TITLE
Update e-hentai hosts

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/EhDns.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhDns.java
@@ -49,7 +49,7 @@ public class EhDns implements Dns {
     static {
         Map<String, List<InetAddress>> map = new HashMap<>();
         if (Settings.getBuiltInHosts()){
-            put(map, "e-hentai.org",  "104.20.135.21","104.20.134.21","172.67.0.127","104.20.26.25","178.162.139.18");
+            put(map, "e-hentai.org",  "104.20.135.21","104.20.134.21","172.67.0.127","178.162.139.18");
             put(map, "repo.e-hentai.org", "94.100.28.57", "94.100.29.73");
             put(map, "forums.e-hentai.org", "94.100.18.243");
             put(map, "ehgt.org", "37.48.89.44", "81.171.10.48", "178.162.139.24", "178.162.140.212"

--- a/app/src/main/java/com/hippo/ehviewer/client/EhDns.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhDns.java
@@ -49,7 +49,7 @@ public class EhDns implements Dns {
     static {
         Map<String, List<InetAddress>> map = new HashMap<>();
         if (Settings.getBuiltInHosts()){
-            put(map, "e-hentai.org",  "104.20.135.21","104.20.134.21","172.67.0.127","178.162.139.18");
+            put(map, "e-hentai.org",  "104.20.135.21","104.20.134.21","172.67.0.127");
             put(map, "repo.e-hentai.org", "94.100.28.57", "94.100.29.73");
             put(map, "forums.e-hentai.org", "94.100.18.243");
             put(map, "ehgt.org", "37.48.89.44", "81.171.10.48", "178.162.139.24", "178.162.140.212"


### PR DESCRIPTION
https://github.com/xiaojieonly/Ehviewer_CN_SXJ/pull/639#issuecomment-1600716145 ，我在此处提到过，104.20.26.25 只是随机的一个 Cloudflare IP ，不能提供 E-Hentai 网页内容。

```bash
u0_a213@localhost ~> curl -v https://104.20.26.25 -k -H "Host: e-hentai.org"
*   Trying 104.20.26.25:443...
* Connected to 104.20.26.25 (104.20.26.25) port 443
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=admweb.admin.stg-2.digitalkmp.com
*  start date: Nov  2 00:00:00 2023 GMT
*  expire date: Nov  1 23:59:59 2024 GMT
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=RapidSSL TLS RSA CA G1
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://104.20.26.25/
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: e-hentai.org]
* [HTTP/2] [1] [:path: /]
* [HTTP/2] [1] [user-agent: curl/8.5.0]
* [HTTP/2] [1] [accept: */*]
> GET / HTTP/2
> Host: e-hentai.org
> User-Agent: curl/8.5.0
> Accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< HTTP/2 403
< server: cloudflare
< date: Sun, 07 Jan 2024 03:23:35 GMT
< content-type: text/html
< content-length: 151
< cf-ray: 8419153bca890478-HKG
<
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>cloudflare</center>
</body>
</html>
* Connection #0 to host 104.20.26.25 left intact
```