### PR TITLE
修复GitHub Action构建

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Build
         run: |


### PR DESCRIPTION
从 [214ba1e](https://github.com/xiaojieonly/Ehviewer_CN_SXJ/commit/214ba1e2dc5c48071e5adb481b394ac1c89ec71a)开始坏了有段时间了，Java版本从11升级到17解决构建错误。