### PR TITLE
Remove jcenter.bintray.com

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jcenter.bintray.com" }
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
End of life, and will trigger an error before build on fdroidserver, as it’s not a known trustworthy source.