### PR TITLE
[fix]filebase未初始化

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/EhClient.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhClient.java
@@ -221,7 +221,10 @@ public class EhClient {
                 if (!(result instanceof CancelledException)) {
                     if (result instanceof Throwable) {
                         mCallback.onFailure((Exception) result);
-                        FirebaseCrashlytics.getInstance().recordException((Throwable) result);
+                        boolean enabled = FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled();
+                        if (enabled) {
+                            FirebaseCrashlytics.getInstance().recordException((Throwable) result);
+                        }
                     } else {
                         mCallback.onSuccess(result);
                     }


### PR DESCRIPTION
Process: com.xjs.ehviewer.debug, PID: 6457
java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process com.xjs.ehviewer.debug. Make sure to call FirebaseApp.initializeApp(Context) first.
	at com.google.firebase.FirebaseApp.getInstance(FirebaseApp.java:179)
	at com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance(FirebaseCrashlytics.java:194)
	at com.hippo.ehviewer.client.EhClient$Task.onPostExecute(EhClient.java:224)
	at android.os.AsyncTask.finish(AsyncTask.java:771)
	at android.os.AsyncTask.-$$Nest$mfinish(Unknown Source:0)
	at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:8061)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:703)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)