### PR TITLE
fix(download): crashed if drag download items

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ImageBitmapHelper.java
+++ b/app/src/main/java/com/hippo/ehviewer/ImageBitmapHelper.java
@@ -35,7 +35,9 @@ public class ImageBitmapHelper implements ValueHelper<Image> {
         try {
             isPipe.obtain();
             FileInputStream is = (FileInputStream) isPipe.open();
-            return Image.decode(is,true);
+            // todo: fix `Software rendering doesn't support hardware bitmaps` when hardware arg is true.
+            // disable hardware canvas.
+            return Image.decode(is,false);
         } catch (OutOfMemoryError e) {
             return null;
         } catch (IOException e) {


### PR DESCRIPTION
将`Image.decode`降级到software模式，解决`Software rendering doesn't support hardware bitmaps`问题

close #2127 
close #2112 
close #2116