### PR TITLE
fix: 修复了在搜索框不为空时的搜索历史补全

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/widget/SearchBar.java
+++ b/app/src/main/java/com/hippo/ehviewer/widget/SearchBar.java
@@ -187,7 +187,7 @@ public class SearchBar extends CardView implements View.OnClickListener,
 
         String[] keywords = mSearchDatabase.getSuggestions(text, 128);
         for (String keyword : keywords) {
-            mSuggestionList.add(new TagSuggestion(null, keyword));
+            mSuggestionList.add(new HistorySuggestion(keyword));
         }
 
         EhTagDatabase ehTagDatabase = EhTagDatabase.getInstance(getContext());
@@ -764,6 +764,40 @@ public class SearchBar extends CardView implements View.OnClickListener,
         @Override
         public void onLongClick() {
             mSearchDatabase.deleteQuery(mKeyword);
+            updateSuggestions(false);
+        }
+    }
+
+    private class HistorySuggestion extends Suggestion {
+
+        private final String mQuery;
+
+        public HistorySuggestion(String query) {
+            mQuery = query;
+        }
+
+        @Override
+        public CharSequence getText(float textSize) {
+            return null;
+        }
+
+        @Override
+        public CharSequence getText(TextView textView) {
+            if (textView.getId() == R.id.hintView) {
+                return mQuery;
+            }
+            return null;
+        }
+
+        @Override
+        public void onClick() {
+            mEditText.setText(mQuery);
+            mEditText.setSelection(mEditText.getText().length());
+        }
+
+        @Override
+        public void onLongClick() {
+            mSearchDatabase.deleteQuery(mQuery);
             updateSuggestions(false);
         }
     }


### PR DESCRIPTION
搜索历史中存在a:"100yen locker$"  l:"chinese$"时

当搜索框内容为a:"100yen locker$"时，点击搜索历史补全会让搜索文本变更为a:"100yen  a:"100yen locker$"  l:"chinese$"

在修复后会直接使用搜索历史文本替换