### PR TITLE
feat(download): 统一搜索对话框折叠面板与排序联动

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/download/DownloadsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/download/DownloadsScene.java
@@ -23,9 +23,20 @@ import static com.hippo.util.FileUtils.getFileName;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.DatePickerDialog;
+import android.app.TimePickerDialog;
 import android.content.Context;
+import android.os.Handler;
+import android.text.TextUtils;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import androidx.appcompat.app.AlertDialog;
 import android.content.DialogInterface;
+import java.util.List;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Point;
@@ -35,9 +46,11 @@ import android.graphics.drawable.NinePatchDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Looper;
 import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.Display;
+import android.text.Editable;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -46,10 +59,23 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.os.Environment;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
@@ -58,6 +84,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
@@ -69,6 +97,8 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.h6ah4i.android.widget.advrecyclerview.animator.DraggableItemAnimator;
 import com.h6ah4i.android.widget.advrecyclerview.animator.GeneralItemAnimator;
 import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
+import com.hippo.ehviewer.local.LocalGalleryManager;
+import com.hippo.ehviewer.client.data.LocalGalleryInfo;
 import com.hippo.android.resource.AttrResources;
 import com.hippo.app.CheckBoxDialogBuilder;
 import com.hippo.drawable.AddDeleteDrawable;
@@ -94,6 +124,7 @@ import com.hippo.ehviewer.event.SomethingNeedRefresh;
 import com.hippo.ehviewer.spider.SpiderInfo;
 import com.hippo.ehviewer.sync.DownloadListInfosExecutor;
 import com.hippo.ehviewer.sync.DownloadSpiderInfoExecutor;
+// removed unused background task imports
 import com.hippo.ehviewer.ui.GalleryActivity;
 import com.hippo.ehviewer.ui.MainActivity;
 import com.hippo.ehviewer.ui.annotation.ViewLifeCircle;
@@ -102,6 +133,8 @@ import com.hippo.ehviewer.ui.scene.download.part.DownloadAdapter;
 import com.hippo.ehviewer.ui.scene.download.part.MyPageChangeListener;
 import com.hippo.ehviewer.widget.MyEasyRecyclerView;
 import com.hippo.ehviewer.widget.SearchBar;
+import com.hippo.ehviewer.ui.scene.download.part.DownloadCategoryTable;
+import com.hippo.ehviewer.widget.AdvanceSearchTable;
 import com.hippo.lib.yorozuya.AssertUtils;
 import com.hippo.lib.yorozuya.ObjectUtils;
 import com.hippo.lib.yorozuya.ViewUtils;
@@ -116,6 +149,37 @@ import com.hippo.widget.ProgressView;
 import com.hippo.widget.SearchBarMover;
 import com.hippo.widget.recyclerview.AutoStaggeredGridLayoutManager;
 import com.sxj.paginationlib.PaginationIndicator;
+import com.hippo.ehviewer.ui.scene.download.part.MyPageChangeListener;
+import com.hippo.ehviewer.ui.scene.download.part.DownloadAdapter;
+import com.hippo.ehviewer.ui.scene.download.part.CheckboxAdapter;
+import com.hippo.util.ExecutorManager;
+import com.hippo.lib.yorozuya.SimpleHandler;
+// ProgressDialogManager removed - using Toast notifications instead
+import com.hippo.ehviewer.util.UiThreadHelper;
+import com.hippo.ehviewer.download.DownloadInfoListener;
+import com.hippo.ehviewer.task.BackgroundTask;
+import com.hippo.ehviewer.task.TaskExecutor;
+import com.hippo.ehviewer.task.impl.CompressSelectedGalleriesTask;
+import com.hippo.ehviewer.task.impl.DeleteFilesTask;
+import com.hippo.ehviewer.task.impl.DeleteRangeDownloadTask;
+import com.hippo.ehviewer.task.impl.StartAllDownloadTask;
+import com.hippo.ehviewer.task.impl.StartRangeDownloadTask;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+// 拖拽排序相关导入
+import com.h6ah4i.android.widget.advrecyclerview.animator.DraggableItemAnimator;
+import com.h6ah4i.android.widget.advrecyclerview.animator.GeneralItemAnimator;
+import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
+import android.graphics.drawable.NinePatchDrawable;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -131,9 +195,9 @@ import java.util.Map;
 import java.util.Objects;
 
 public class DownloadsScene extends ToolbarScene
-        implements DownloadManager.DownloadInfoListener, DownloadSearchCallback,
-        MyEasyRecyclerView.OnItemClickListener,
-        MyEasyRecyclerView.OnItemLongClickListener,
+        implements DownloadInfoListener, DownloadSearchCallback,
+        EasyRecyclerView.OnItemClickListener,
+        EasyRecyclerView.OnItemLongClickListener,
         FabLayout.OnClickFabListener, FabLayout.OnExpandListener, FastScroller.OnDragHandlerListener, SearchBar.Helper, SearchBarMover.Helper, SearchBar.OnStateChangeListener, DownloadAdapter.DownloadAdapterCallback {
 
     private static final String TAG = DownloadsScene.class.getSimpleName();
@@ -161,9 +225,13 @@ public class DownloadsScene extends ToolbarScene
     @Nullable
     public String mLabel;
     @Nullable
+    private String mCurrentLabel;
+    @Nullable
     private List<DownloadInfo> mList;
     @Nullable
     private List<DownloadInfo> mBackList;
+    @Nullable
+    private ArrayAdapter<DownloadLabel> mLabelAdapter;
 
     /*---------------
      List pagination
@@ -172,13 +240,42 @@ public class DownloadsScene extends ToolbarScene
     private int pageSize = 1;
     private boolean canPagination = true;
     private final int paginationSize = 500;
+
+    // 排序和过滤相关变�?
+    private AlertDialog mSortFilterDialog;
+    private CheckboxAdapter mCategoryAdapter;
+    private CheckboxAdapter mStatusAdapter;
+    private Spinner mCategorySpinner;
+    private CheckboxAdapter mSortAdapter;
+    private Set<Integer> mSelectedCategories = new HashSet<>();
+    private Set<Integer> mSelectedStatuses = new HashSet<>();
+    private Set<Integer> mSelectedSorts = new HashSet<>();
+    @Nullable
+    private Long mFilterTimeFrom;
+    @Nullable
+    private Long mFilterTimeTo;
+    @Nullable
+    private Long mFilterSizeFrom;
+    @Nullable
+    private Long mFilterSizeTo;
+    private boolean mFilterDuplicateOnly = false;
+    private String mFilterTimeFromInput = "";
+    private String mFilterTimeToInput = "";
+    private String mFilterSizeFromInput = "";
+    private String mFilterSizeToInput = "";
     //    private final int paginationSize = 5;
     private final int[] perPageCountChoices = {50, 100, 200, 300, 500};
 //    private final int[] perPageCountChoices = {1, 2, 3, 4, 5};
 
     private MyPageChangeListener myPageChangeListener;
 
-    private final Map<Long, SpiderInfo> mSpiderInfoMap = new HashMap<>();
+    private final Map<Long, SpiderInfo> mSpiderInfoMap = new HashMap<>(64);
+    
+    // 缓存的 MainLooper Handler，避免重复创建
+    private final Handler mMainHandler = new Handler(Looper.getMainLooper());
+    
+    // 添加页码切换标志位，避免与进度更新冲�?
+    private volatile boolean isPageChanging = false;
 
     /*---------------
      View life cycle
@@ -196,7 +293,7 @@ public class DownloadsScene extends ToolbarScene
     @Nullable
     private AutoStaggeredGridLayoutManager mLayoutManager;
 
-    // 拖拽管理器
+    // 拖拽管理�?
     @Nullable
     private RecyclerViewDragDropManager mDragDropManager;
 
@@ -214,6 +311,7 @@ public class DownloadsScene extends ToolbarScene
     @ViewLifeCircle
     private SearchBarMover mSearchBarMover;
     private boolean mSearchMode = false;
+    private boolean isFilteringOrSearching = false;  // 标记是否处于筛选或搜索状�?
     public String searchKey = null;
 
     private int mInitPosition = -1;
@@ -224,8 +322,6 @@ public class DownloadsScene extends ToolbarScene
     private boolean needInitPage = false;
     private boolean needInitPageSize = false;
 
-    @Nullable
-    private Spinner mCategorySpinner;
     private int mSelectedCategory = EhUtils.ALL_CATEGORY;
 
     @NonNull
@@ -342,28 +438,46 @@ public class DownloadsScene extends ToolbarScene
             mAdapter.notifyDataSetChanged();
         }
         mBackList = mList;
+        isFilteringOrSearching = false;  // 切换标签时退出筛选状�?
 //        filterByCategory();
         updateTitle();
-        updatePaginationIndicator();
+        updatePaginationIndicator(true); // 标签变化时强制重新初始化
         Settings.putRecentDownloadLabel(mLabel);
         queryUnreadSpiderInfo();
     }
 
     private void updatePaginationIndicator() {
+        updatePaginationIndicator(false);
+    }
+    
+    private void updatePaginationIndicator(boolean forceReinit) {
         if (mPaginationIndicator == null || mList == null) {
             return;
         }
-        if (mList.size() < paginationSize || !canPagination) {
+        
+        // 如果处于筛选或搜索模式，使用当前结果列表大小；否则检查是否需要分�?
+        int currentListSize = mList.size();
+        
+        // 判断是否需要显示分页：列表大小要超过阈值且支持分页
+        if (currentListSize < paginationSize || !canPagination) {
             mPaginationIndicator.setVisibility(View.GONE);
             return;
         }
-        mPaginationIndicator.setVisibility(View.VISIBLE);
-        needInitPageSize = true;
-        mPaginationIndicator.initPaginationIndicator(pageSize, perPageCountChoices, mList.size(), indexPage);
-//        mPaginationIndicator.setTotalCount();
-        mPaginationIndicator.setListener(myPageChangeListener);
-
-        // 同步分页监听器的状态
+        
+        // 只在必要时才重新初始�?
+        if (forceReinit || needInitPageSize) {
+            mPaginationIndicator.setVisibility(View.VISIBLE);
+            needInitPageSize = false;
+            // 使用当前结果列表的大小初始化分页，而非原始列表
+            mPaginationIndicator.initPaginationIndicator(pageSize, perPageCountChoices, currentListSize, indexPage);
+            
+            // 只在第一次或强制重新初始化时设置监听�?
+            if (myPageChangeListener != null) {
+                mPaginationIndicator.setListener(myPageChangeListener);
+            }
+        }
+        
+        // 同步分页监听器的状�?
         if (myPageChangeListener != null) {
             myPageChangeListener.setIndexPage(indexPage);
             myPageChangeListener.setPageSize(pageSize);
@@ -530,6 +644,22 @@ public class DownloadsScene extends ToolbarScene
             @Override
             public void onPageChanged(int newIndexPage) {
                 indexPage = newIndexPage;
+                // 设置页码切换标志
+                isPageChanging = true;
+                
+                // 页码切换时，延迟更新列表以避免与进度更新冲突
+                if (mAdapter != null) {
+                    mMainHandler.postDelayed(() -> {
+                        try {
+                            mAdapter.notifyDataSetChanged();
+                            // 重置页码切换标志
+                            isPageChanging = false;
+                        } catch (Exception e) {
+                            android.util.Log.e("DownloadsScene", "Error updating adapter after page change: " + e.getMessage());
+                            isPageChanging = false;
+                        }
+                    }, 150); // 延迟150ms执行，确保页码切换完�?
+                }
             }
 
             @Override
@@ -541,7 +671,7 @@ public class DownloadsScene extends ToolbarScene
         mLayoutManager.setColumnSize(resources.getDimensionPixelOffset(Settings.getDetailSizeResId()));
         mLayoutManager.setStrategy(AutoStaggeredGridLayoutManager.STRATEGY_MIN_SIZE);
 
-        // 设置拖拽动画器
+        // 设置拖拽动画�?
         final GeneralItemAnimator animator = new DraggableItemAnimator();
         mRecyclerView.setItemAnimator(animator);
 
@@ -601,8 +731,14 @@ public class DownloadsScene extends ToolbarScene
         mFabLayout.setAutoCancel(false);
         mFabLayout.setOnClickFabListener(this);
         mFabLayout.setOnExpandListener(this);
+        mFabLayout.setShowFabFunctionName(Settings.getShowFabFunctionName());
         mActionFabDrawable = new AddDeleteDrawable(context, resources.getColor(R.color.primary_drawable_dark, null));
         mFabLayout.getPrimaryFab().setImageDrawable(mActionFabDrawable);
+        mFabLayout.getPrimaryFab().setContentDescription(getString(R.string.fab_action_menu));
+        
+        // 为FloatingActionButton添加标签
+        setupFabLabels();
+        
         FloatingActionButton fab = mFabLayout.getSecondaryFabAt(6);
         if (DRAG_ENABLE) {
             fab.setImageDrawable(ResourcesCompat.getDrawable(getResources(), R.drawable.v_mobile_hand_left_x24, context.getTheme()));
@@ -614,7 +750,7 @@ public class DownloadsScene extends ToolbarScene
         updateView();
 
         guide();
-        updatePaginationIndicator();
+        updatePaginationIndicator(true); // 首次初始化时强制重新初始�?
         return view;
     }
 
@@ -702,6 +838,25 @@ public class DownloadsScene extends ToolbarScene
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        if (mFabLayout != null) {
+            mFabLayout.setShowFabFunctionName(Settings.getShowFabFunctionName());
+        }
+    }
+
+    private void startAllDownloads() {
+        Activity activity = getActivity2();
+        if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+            return;
+        }
+        
+        StartAllDownloadTask task = new StartAllDownloadTask(activity);
+        com.hippo.ehviewer.BackgroundTaskManager.getInstance().submitBackgroundTask(task);
+        Toast.makeText(activity, R.string.start_all_download, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         updateTitle();
@@ -756,14 +911,16 @@ public class DownloadsScene extends ToolbarScene
         int id = item.getItemId();
         switch (id) {
             case R.id.action_start_all: {
-                Intent intent = new Intent(activity, DownloadService.class);
-                intent.setAction(DownloadService.ACTION_START_ALL);
-                activity.startService(intent);
+                if (mDownloadManager == null) {
+                    return false;
+                }
+                
+                DownloadService.startAllDownloads(activity);
                 return true;
             }
             case R.id.action_stop_all: {
-                if (null != mDownloadManager) {
-                    mDownloadManager.stopAllDownload();
+                if (activity != null) {
+                    DownloadService.stopAllDownloads(activity);
                 }
                 return true;
             }
@@ -773,7 +930,7 @@ public class DownloadsScene extends ToolbarScene
                     return false;
                 }
                 if (searching) {
-                    Toast.makeText(context, R.string.download_searching, Toast.LENGTH_LONG).show();
+                    UiThreadHelper.showToastSafely(context, R.string.download_searching, Toast.LENGTH_LONG);
                     return true;
                 }
                 new AlertDialog.Builder(context)
@@ -824,7 +981,15 @@ public class DownloadsScene extends ToolbarScene
             case R.id.western:
             case R.id.unknown:
                 gotoFilterAndSort(id);
+            case R.id.sort_download_list: {
+                // 不再显示排序窗口，直接使用菜单中的排序选项
                 return true;
+            }
+            case R.id.advanced_filter: {
+                Log.d("DownloadsScene", "onOptionsItemSelected: 高级过滤按钮被点");
+                showSortFilterDialog();
+                return true;
+            }
             case R.id.import_local_archive:
                 importLocalArchive();
                 return true;
@@ -846,50 +1011,184 @@ public class DownloadsScene extends ToolbarScene
     }
 
     private void gotoSearch(Context context) {
-        if (mSearchDialog != null) {
+        if (mSearchDialog != null && mSearchDialog.isShowing()) {
             mSearchDialog.show();
             return;
         }
-        LayoutInflater layoutInflater = LayoutInflater.from(context);
-
-        Drawable drawable = DrawableManager.getVectorDrawable(context, R.drawable.big_download);
-
-        LinearLayout linearLayout = (LinearLayout) layoutInflater.inflate(R.layout.download_search_dialog, null);
-        mSearchBar = linearLayout.findViewById(R.id.download_search_bar);
-        mSearchBar.setHelper(this);
-        mSearchBar.setIsComeFromDownload(true);
-        mSearchBar.setEditTextHint(R.string.download_search_hint);
-        mSearchBar.setLeftDrawable(drawable);
-        mSearchBar.setText(searchKey);
-        if (searchKey != null && !searchKey.isEmpty()) {
-            mSearchBar.setTitle(searchKey);
-            mSearchBar.cursorToEnd();
-        } else {
-            mSearchBar.setTitle(R.string.download_search_hint);
+        if (mSearchDialog != null) {
+            mSearchDialog.dismiss();
+            mSearchDialog = null;
         }
+        
+        // 创建增强的搜索对话框
+        View dialogView = LayoutInflater.from(context).inflate(R.layout.download_search_dialog_v2, null);
+        
+        // 获取各个组件
+        SearchBar searchBar = dialogView.findViewById(R.id.download_search_bar);
+        mSearchBar = searchBar; // 供回调使用，避免空指�?
+        AdvanceSearchTable advanceSearchTable = dialogView.findViewById(R.id.advance_search_table);
+        DownloadCategoryTable categoryTable = dialogView.findViewById(R.id.category_table);
+        RecyclerView searchSortRecyclerView = dialogView.findViewById(R.id.search_sort_recycler_view);
+        View advanceSearchToggleRow = dialogView.findViewById(R.id.advance_search_toggle_row);
+        TextView advanceSearchToggleIcon = dialogView.findViewById(R.id.advance_search_toggle_icon);
+        View advanceSearchContentContainer = dialogView.findViewById(R.id.advance_search_content_container);
+        View categoryFilterToggleRow = dialogView.findViewById(R.id.category_filter_toggle_row);
+        TextView categoryFilterToggleIcon = dialogView.findViewById(R.id.category_filter_toggle_icon);
+        View categoryFilterContentContainer = dialogView.findViewById(R.id.category_filter_content_container);
+        Button resetButton = dialogView.findViewById(R.id.reset_button);
+        Button searchButton = dialogView.findViewById(R.id.search_button);
 
-        mSearchBar.setRightDrawable(DrawableManager.getVectorDrawable(context, R.drawable.v_magnify_x24));
-        mSearchBarMover = new SearchBarMover(this, mSearchBar);
+        // 高级搜索选项和分类过滤默认折叠
+        setSectionExpanded(advanceSearchContentContainer, advanceSearchToggleIcon, false);
+        setSectionExpanded(categoryFilterContentContainer, categoryFilterToggleIcon, false);
+        advanceSearchToggleRow.setOnClickListener(v -> toggleSection(advanceSearchContentContainer, advanceSearchToggleIcon));
+        categoryFilterToggleRow.setOnClickListener(v -> toggleSection(categoryFilterContentContainer, categoryFilterToggleIcon));
+
+        int spanCount = context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ? 2 : 1;
+        searchSortRecyclerView.setLayoutManager(new GridLayoutManager(context, spanCount));
+        searchSortRecyclerView.setNestedScrollingEnabled(false);
+
+        List<String> sortItems = new ArrayList<>();
+        List<Integer> sortIds = new ArrayList<>();
+        sortItems.add(getString(R.string.default_sort));
+        sortIds.add(R.id.sort_by_default);
+        sortItems.add(getString(R.string.sort_by_gallery_id_asc));
+        sortIds.add(R.id.sort_by_gallery_id_asc);
+        sortItems.add(getString(R.string.sort_by_gallery_id_desc));
+        sortIds.add(R.id.sort_by_gallery_id_desc);
+        sortItems.add(getString(R.string.sort_by_create_time_asc));
+        sortIds.add(R.id.sort_by_create_time_asc);
+        sortItems.add(getString(R.string.sort_by_create_time_desc));
+        sortIds.add(R.id.sort_by_create_time_desc);
+        sortItems.add(getString(R.string.sort_by_rating_asc));
+        sortIds.add(R.id.sort_by_rating_asc);
+        sortItems.add(getString(R.string.sort_by_rating_desc));
+        sortIds.add(R.id.sort_by_rating_desc);
+        sortItems.add(getString(R.string.sort_by_name_asc));
+        sortIds.add(R.id.sort_by_name_asc);
+        sortItems.add(getString(R.string.sort_by_name_desc));
+        sortIds.add(R.id.sort_by_name_desc);
+        sortItems.add(getString(R.string.sort_by_file_size_asc));
+        sortIds.add(R.id.sort_by_file_size_asc);
+        sortItems.add(getString(R.string.sort_by_file_size_desc));
+        sortIds.add(R.id.sort_by_file_size_desc);
+
+        CheckboxAdapter searchSortAdapter = new CheckboxAdapter(sortItems, sortIds);
+        searchSortAdapter.setMutuallyExclusive(true);
+        if (mSelectedSorts.isEmpty()) {
+            mSelectedSorts.add(R.id.sort_by_default);
+        }
+        searchSortRecyclerView.setAdapter(searchSortAdapter);
+        dialogView.post(() -> searchSortAdapter.setSelectedItems(mSelectedSorts));
+        searchSortAdapter.setOnSelectionChangedListener(selectedItems -> {
+            mSelectedSorts.clear();
+            mSelectedSorts.addAll(selectedItems);
+            if (mSelectedSorts.isEmpty()) {
+                mSelectedSorts.add(R.id.sort_by_default);
+                dialogView.post(() -> searchSortAdapter.setSelectedItems(mSelectedSorts));
+            }
+        });
+        
+        // 设置SearchBar
+        searchBar.setHelper(this);
+        searchBar.setIsComeFromDownload(true);
+        searchBar.setEditTextHint(R.string.download_search_hint);
+        searchBar.setText(searchKey);
+        if (searchKey != null && !searchKey.isEmpty()) {
+            searchBar.setTitle(searchKey);
+            searchBar.cursorToEnd();
+        } else {
+            searchBar.setTitle(R.string.download_search_hint);
+        }
+        searchBar.setRightDrawable(DrawableManager.getVectorDrawable(context, R.drawable.v_magnify_x24));
+        
+        // 设置SearchBar为搜索状态，但不立即显示建议列表
+        searchBar.setState(SearchBar.STATE_SEARCH, false);
+        
+        // 确保EditText可以获取焦点和点�?
+        searchBar.mEditText.setFocusable(true);
+        searchBar.mEditText.setFocusableInTouchMode(true);
+        searchBar.mEditText.setClickable(true);
+        
+        // 设置默认搜索选项
+        advanceSearchTable.setAdvanceSearch(AdvanceSearchTable.SNAME | AdvanceSearchTable.STAGS);
+        
+        // 设置默认分类为全�?- 确保所有按钮都是亮起的
+        Set<Integer> defaultCategories = new HashSet<>();
+        defaultCategories.add(EhUtils.ALL_CATEGORY);
+        categoryTable.setSelectedCategories(defaultCategories);
+        
+        resetButton.setOnClickListener(v -> {
+            searchBar.setText("");
+            searchBar.setTitle(R.string.download_search_hint);
+            advanceSearchTable.setAdvanceSearch(AdvanceSearchTable.SNAME | AdvanceSearchTable.STAGS);
+
+            Set<Integer> resetCategories = new HashSet<>();
+            resetCategories.add(EhUtils.ALL_CATEGORY);
+            categoryTable.setSelectedCategories(resetCategories);
+
+            mSelectedSorts.clear();
+            mSelectedSorts.add(R.id.sort_by_default);
+            dialogView.post(() -> searchSortAdapter.setSelectedItems(mSelectedSorts));
+            searchBar.hideSuggestionsList();
+        });
+
+        searchButton.setOnClickListener(v -> {
+            Editable editable = searchBar.mEditText.getText();
+            searchKey = editable != null ? editable.toString() : null;
+
+            int searchOption = advanceSearchTable.getAdvanceSearch();
+            Set<Integer> selectedCategories = categoryTable.getSelectedCategories();
+            int selectedSort = mSelectedSorts.isEmpty() ? R.id.sort_by_default : mSelectedSorts.iterator().next();
+
+            searchBar.hideSuggestionsList();
+            performAdvancedSearch(searchKey, searchOption, selectedCategories, selectedSort);
+            mSearchDialog.dismiss();
+        });
+
         mSearchDialog = new AlertDialog.Builder(context)
-                .setMessage(R.string.download_search_gallery)
-                .setView(linearLayout)
+                .setView(dialogView)
                 .setCancelable(true)
-                .setOnDismissListener(this::onSearchDialogDismiss)
-                .setNegativeButton(android.R.string.cancel, (dialog, which) -> {
-                    searchKey = null;
-                    mSearchBar.setText(null);
-                    mSearchBar.setTitle(null);
-                    mSearchBar.applySearch(true);
-                    dialog.dismiss();
-                })
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                    mSearchBar.applySearch(true);
-                    dialog.dismiss();
-                }).show();
+                .create();
+        mSearchDialog.setOnDismissListener(dialog -> {
+            if (searchBar != null) {
+                searchBar.hideSuggestionsList();
+            }
+            onSearchDialogDismiss(dialog);
+        });
+        mSearchDialog.show();
+    }
+    
+    // 新增方法：执行高级搜�?
+    private void performAdvancedSearch(String keyword, int searchOption, Set<Integer> categories, int sortId) {
+        Log.d("DownloadsScene", "performAdvancedSearch: keyword=" + keyword + ", searchOption=" + searchOption + ", categories=" + categories + ", sortId=" + sortId);
+        
+        isFilteringOrSearching = true;  // 标记进入搜索状�?
+        mProgressView.setVisibility(View.VISIBLE);
+        if (mRecyclerView != null) {
+            mRecyclerView.setVisibility(View.GONE);
+        }
+        
+        // 创建执行器并执行搜索
+        DownloadListInfosExecutor executor = new DownloadListInfosExecutor(mBackList, mDownloadManager);
+        executor.setDownloadSearchingListener(this);
+        executor.executeAdvancedSearch(keyword, searchOption, categories, sortId);
     }
 
     private void onSearchDialogDismiss(DialogInterface dialog) {
         mSearchMode = false;
+        mSearchDialog = null;
+        mSearchBar = null; // 释放引用，避免后续回调访问空对象
+    }
+
+    private void setSectionExpanded(@NonNull View sectionContent, @NonNull TextView indicatorView, boolean expanded) {
+        sectionContent.setVisibility(expanded ? View.VISIBLE : View.GONE);
+        indicatorView.setText(expanded ? "-" : "+");
+    }
+
+    private void toggleSection(@NonNull View sectionContent, @NonNull TextView indicatorView) {
+        boolean shouldExpand = sectionContent.getVisibility() != View.VISIBLE;
+        setSectionExpanded(sectionContent, indicatorView, shouldExpand);
     }
 
     private void enterSearchMode(boolean animation) {
@@ -980,7 +1279,7 @@ public class DownloadsScene extends ToolbarScene
                     // Test if we can access the URI
                     try (InputStream testStream = getEHContext().getContentResolver().openInputStream(archiveUri)) {
                         if (testStream == null) {
-                            Toast.makeText(getEHContext(), R.string.archive_not_accessible, Toast.LENGTH_SHORT).show();
+                            UiThreadHelper.showToastSafely(getEHContext(), R.string.archive_not_accessible, Toast.LENGTH_SHORT);
                             return true;
                         }
                     }
@@ -990,12 +1289,12 @@ public class DownloadsScene extends ToolbarScene
                         getEHContext().getContentResolver().takePersistableUriPermission(archiveUri,
                                 Intent.FLAG_GRANT_READ_URI_PERMISSION);
                     } catch (Exception ex) {
-                        Toast.makeText(getEHContext(), R.string.archive_permission_lost, Toast.LENGTH_LONG).show();
+                        UiThreadHelper.showToastSafely(getEHContext(), R.string.archive_permission_lost, Toast.LENGTH_LONG);
                         Analytics.recordException(ex);
                         return true;
                     }
                 } catch (Exception e) {
-                    Toast.makeText(getEHContext(), R.string.archive_not_accessible, Toast.LENGTH_SHORT).show();
+                    UiThreadHelper.showToastSafely(getEHContext(), R.string.archive_not_accessible, Toast.LENGTH_SHORT);
                     return true;
                 }
                 intent.setAction(Intent.ACTION_VIEW);
@@ -1077,7 +1376,7 @@ public class DownloadsScene extends ToolbarScene
             LongList gidList = null;
             List<DownloadInfo> downloadInfoList = null;
             boolean collectGid = position == 1 || position == 2 || position == 3; // Start, Stop, Delete
-            boolean collectDownloadInfo = position == 3 || position == 4; // Delete or Move
+            boolean collectDownloadInfo = position == 3 || position == 4 || position == 7; // Delete or Move or Zip
             if (collectGid) {
                 gidList = new LongList();
             }
@@ -1103,10 +1402,10 @@ public class DownloadsScene extends ToolbarScene
                     if (gidList.isEmpty()) {
                         break;
                     }
-                    Intent intent = new Intent(activity, DownloadService.class);
-                    intent.setAction(DownloadService.ACTION_START_RANGE);
-                    intent.putExtra(DownloadService.KEY_GID_LIST, gidList);
-                    activity.startService(intent);
+                    // 使用后台任务处理多选下载，避免界面卡顿
+                    StartRangeDownloadTask task = new StartRangeDownloadTask(activity, gidList);
+                    TaskExecutor.getInstance().execute(task);
+                    Toast.makeText(context, R.string.background_task_submitted, Toast.LENGTH_SHORT).show();
                     // Cancel check mode
                     recyclerView.outOfCustomChoiceMode();
                     break;
@@ -1157,15 +1456,21 @@ public class DownloadsScene extends ToolbarScene
                             .show();
                     break;
                 }
-                case 5:
+                case 5: // Random Play
                     if (mList == null || mList.isEmpty()) {
                         return;
                     }
                     onClickPrimaryFab(mFabLayout, null);
                     viewRandom();
                     break;
-                case 6:
+                case 6: // Drap
                     setDragEnable(fab);
+                    break;
+                case 7: // Zip
+                    compressSelectedGalleries(downloadInfoList);
+                    break;
+                case 8: //Refresh
+                    refreshCurrentPage();
                     break;
             }
         }
@@ -1182,6 +1487,55 @@ public class DownloadsScene extends ToolbarScene
             fab.setImageDrawable(ResourcesCompat.getDrawable(getResources(), R.drawable.v_mobile_hand_left_off_x24, context.getTheme()));
         }
 //        mDragDropManager.cancelDrag(dragEnable);
+    }
+
+    private void setupFabLabels() {
+        Context context = getEHContext();
+        if (null == context || null == mFabLayout) {
+            return;
+        }
+        
+        // 为每个SecondaryFab添加标签
+        String[] labels = {
+            getString(R.string.select_all),
+            getString(R.string.start_all_download),
+            getString(R.string.pause_all_download),
+            getString(R.string.delete_download),
+            getString(R.string.move_download),
+            getString(R.string.random_download),
+            getString(R.string.drag_mode),
+            getString(R.string.compress_selected_galleries),
+            getString(R.string.refresh_current_page)
+        };
+        
+        for (int i = 0; i < mFabLayout.getSecondaryFabCount() && i < labels.length; i++) {
+            FloatingActionButton fab = mFabLayout.getSecondaryFabAt(i);
+            if (fab != null) {
+                // 设置内容描述作为标签
+                fab.setContentDescription(labels[i]);
+            }
+        }
+    }
+
+    private void refreshCurrentPage() {
+        if (mDownloadManager != null) {
+            // 重新加载当前页面的数�?
+            updateView();
+            showTip(R.string.refreshed, LENGTH_SHORT);
+        }
+    }
+
+    private void refreshDownloadListAfterDelete() {
+        // 依据当前筛�?搜索状态刷新列�?
+        if (searchKey != null && !searchKey.isEmpty()) {
+            startSearching();
+        } else if (isFilteringOrSearching) {
+            applySortAndFilter();
+        } else {
+            updateForLabel();
+        }
+
+        updateView();
     }
 
     private void viewRandom() {
@@ -1204,11 +1558,148 @@ public class DownloadsScene extends ToolbarScene
         galleryActivityLauncher.launch(intent);
     }
 
+    private void compressSelectedGalleries(List<DownloadInfo> selectedList) {
+        if (selectedList == null || selectedList.isEmpty()) {
+            showTip(R.string.empty_select_download_info, LENGTH_SHORT);
+            return;
+        }
+
+        Context context = getEHContext();
+        if (context == null) {
+            return;
+        }
+
+        Toast.makeText(context, R.string.compress_selected_galleries, Toast.LENGTH_SHORT).show();
+
+        CompressSelectedGalleriesTask task = new CompressSelectedGalleriesTask(context, selectedList);
+        task.setProgressListener(new BackgroundTask.ProgressListener() {
+            @Override
+            public void onProgressChanged(int progress, String detail) {
+                // Progress updates handled via notification, no UI update needed here
+            }
+
+            @Override
+            public void onProgressChanged(int current, int total, String detail) {
+                // Progress updates handled via notification, no UI update needed here
+            }
+
+            @Override
+            public void onCompleted() {
+                List<String> outFiles = task.getOutputFileNames();
+                String result = outFiles.isEmpty() ? "" : TextUtils.join(", ", outFiles);
+                String message = result.isEmpty() ? getString(R.string.compress_success_no_output) : getString(R.string.compress_success_multi, result);
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                Toast.makeText(context, getString(R.string.compress_failed) + ": " + error.getMessage(), Toast.LENGTH_LONG).show();
+            }
+        });
+
+        com.hippo.ehviewer.BackgroundTaskManager.getInstance().submitBackgroundTask(task);
+    }
+
+    private void addUniFileToZip(UniFile uniFile, String basePath, ZipOutputStream zos, Set<String> addedEntries) throws IOException {
+        if (uniFile.isDirectory()) {
+            if (!basePath.endsWith("/")) {
+                basePath += "/";
+            }
+            if (addedEntries.contains(basePath)) {
+                Log.i(TAG, "Skip duplicate directory entry: " + basePath);
+            } else {
+                zos.putNextEntry(new ZipEntry(basePath));
+                zos.closeEntry();
+                addedEntries.add(basePath);
+            }
+
+            UniFile[] children = uniFile.listFiles();
+            if (children != null) {
+                for (UniFile child : children) {
+                    String childPath = basePath + sanitizeFileName(child.getName());
+                    try {
+                        addUniFileToZip(child, childPath, zos, addedEntries);
+                    } catch (IOException e) {
+                        // Log and continue with remaining files
+                        Log.e(TAG, "Failed to add child " + childPath + " to zip", e);
+                    }
+                }
+            }
+        } else if (uniFile.isFile()) {
+            String entryName = basePath;
+            if (entryName == null || entryName.isEmpty()) {
+                entryName = sanitizeFileName(uniFile.getName());
+            }
+            if (addedEntries.contains(entryName)) {
+                Log.i(TAG, "Skip duplicate file entry: " + entryName);
+                return;
+            }
+
+            zos.putNextEntry(new ZipEntry(entryName));
+            InputStream is = uniFile.openInputStream();
+            if (is != null) {
+                try (BufferedInputStream bis = new BufferedInputStream(is)) {
+                    byte[] buffer = new byte[8192];
+                    int count;
+                    while ((count = bis.read(buffer)) != -1) {
+                        zos.write(buffer, 0, count);
+                    }
+                } catch (IOException e) {
+                    String fileName = uniFile.getName() != null ? uniFile.getName() : "unknown";
+                    Log.e(TAG, "Error reading file " + fileName, e);
+                    zos.closeEntry();
+                    throw e;
+                }
+            }
+            zos.closeEntry();
+            addedEntries.add(entryName);
+        }
+    }
+
+    private String sanitizeFileName(String input) {
+        if (input == null) return "";
+        return input.replaceAll("[\\\\/:*?\"<>|]", "_");
+    }
+
     @Override
     public void onAdd(@NonNull DownloadInfo info, @NonNull List<DownloadInfo> list, int position) {
         if (mList != list) {
+            // 如果列表不匹配，尝试在当前列表中查找是否已存在该项目
+            boolean found = false;
+            for (int i = 0; i < mList.size(); i++) {
+                DownloadInfo item = mList.get(i);
+                if (item.gid == info.gid) {
+                    // 项目已存在，更新信息
+                    item.title = info.title;
+                    item.finished = info.finished;
+                    item.downloaded = info.downloaded;
+                    item.total = info.total;
+                    item.legacy = info.legacy;
+                    item.state = info.state;
+                    item.speed = info.speed;
+                    item.remaining = info.remaining;
+                    
+                    // 通知更新
+                    if (mAdapter != null) {
+                        mAdapter.notifyItemChanged(listIndexInPage(i));
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            
+            if (!found) {
+                // 项目不存在，添加到当前列�?
+                Log.d(TAG, "onAdd: 项目不存在，添加到当前列表，GID: " + info.gid);
+                // 这里需要谨慎处理，因为直接添加可能会破坏列表结�?
+                // 最好的方式是触发列表刷�?
+                updateForLabel();
+                updateView();
+            }
             return;
         }
+        
+        // 原有逻辑
         if (mAdapter != null) {
             mAdapter.notifyItemInserted(position);
         }
@@ -1223,28 +1714,97 @@ public class DownloadsScene extends ToolbarScene
         if (mList == null) {
             return;
         }
-        updateForLabel();
-        updateView();
-
-        int index = mList.indexOf(newInfo);
-        if (index >= 0 && mAdapter != null) {
-//            mSpiderInfoMap.put(info.gid,getSpiderInfo(info));
-            mAdapter.notifyItemChanged(listIndexInPage(index));
+        
+        // 尝试在当前列表中找到对应的项�?
+        boolean found = false;
+        for (int i = 0; i < mList.size(); i++) {
+            DownloadInfo item = mList.get(i);
+            if (item.gid == oldInfo.gid) {
+                // 更新项目信息
+                item.title = newInfo.title;
+                item.finished = newInfo.finished;
+                item.downloaded = newInfo.downloaded;
+                item.total = newInfo.total;
+                item.legacy = newInfo.legacy;
+                item.state = newInfo.state;
+                item.speed = newInfo.speed;
+                item.remaining = newInfo.remaining;
+                
+                // 通知更新
+                if (mAdapter != null) {
+                    mAdapter.notifyItemChanged(listIndexInPage(i));
+                }
+                found = true;
+                break;
+            }
         }
-        List<DownloadInfo> infos = new ArrayList<>();
-        infos.add(newInfo);
-        DownloadSpiderInfoExecutor executor = new DownloadSpiderInfoExecutor(infos, this::spiderInfoResultCallBack);
-        executor.execute();
+        
+        if (!found) {
+            Log.d(TAG, "onReplace: 在当前列表中未找到对应的项目，GID: " + oldInfo.gid);
+            // 如果找不到，回退到原来的逻辑
+            updateForLabel();
+            updateView();
+        } else {
+            // 如果找到了，更新视图
+            updateView();
+        }
     }
 
     @Override
     public void onUpdate(@NonNull DownloadInfo info, @NonNull List<DownloadInfo> list, LinkedList<DownloadInfo> mWaitList) {
-        if (mList != list && !mList.contains(info)) {
+        // 如果正在页码切换，延迟处理进度更新
+        if (isPageChanging) {
+            mMainHandler.postDelayed(() -> onUpdate(info, list, mWaitList), 200);
+            return;
+        }
+        
+        if (mList != list) {
+            // 如果列表不匹配，尝试在当前列表中找到对应的项�?
+            boolean found = false;
+            for (int i = 0; i < mList.size(); i++) {
+                DownloadInfo item = mList.get(i);
+                if (item.gid == info.gid) {
+                    // 更新项目信息
+                    item.title = info.title;
+                    item.finished = info.finished;
+                    item.downloaded = info.downloaded;
+                    item.total = info.total;
+                    item.legacy = info.legacy;
+                    item.state = info.state;
+                    item.speed = info.speed;
+                    item.remaining = info.remaining;
+                    
+                    // 使用payload通知更新，避免整个item重绘，提高性能
+                    if (mAdapter != null) {
+                        try {
+                            mAdapter.notifyItemChanged(listIndexInPage(i), "progress");
+                        } catch (Exception e) {
+                            android.util.Log.e("DownloadsScene", "Error notifying item change: " + e.getMessage());
+                        }
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            
+            if (!found) {
+                Log.d(TAG, "onUpdate: 在当前列表中未找到对应的项目，GID: " + info.gid);
+            }
+            return;
+        }
+        
+        // 原有逻辑
+        if (!mList.contains(info)) {
             return;
         }
         int index = mList.indexOf(info);
         if (index >= 0 && mAdapter != null) {
-            mAdapter.notifyItemChanged(listIndexInPage(index));
+            // 使用payload通知更新，避免整个item重绘，提高性能
+            try {
+                mAdapter.notifyItemChanged(listIndexInPage(index), "progress");
+            } catch (Exception e) {
+                android.util.Log.e("DownloadsScene", "Error notifying item change: " + e.getMessage());
+            }
         }
     }
 
@@ -1252,7 +1812,17 @@ public class DownloadsScene extends ToolbarScene
     @Override
     public void onUpdateAll() {
         if (mAdapter != null) {
-            mAdapter.notifyDataSetChanged();
+            // 确保在主线程中更新UI
+            if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+                mAdapter.notifyDataSetChanged();
+            } else {
+                // 在后台线程中，使用Handler切换到主线程
+                mMainHandler.post(() -> {
+                    if (mAdapter != null) {
+                        mAdapter.notifyDataSetChanged();
+                    }
+                });
+            }
         }
     }
 
@@ -1260,16 +1830,32 @@ public class DownloadsScene extends ToolbarScene
     @Override
     public void onReload() {
         if (mAdapter != null) {
-            mAdapter.notifyDataSetChanged();
+            if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+                refreshDownloadListAfterDelete();
+                mOriginalAdapter.preloadFolderMetaAsync();
+            } else {
+                mMainHandler.post(() -> {
+                    refreshDownloadListAfterDelete();
+                    mOriginalAdapter.preloadFolderMetaAsync();
+                });
+            }
         }
-        updateView();
     }
 
     @Override
     public void onChange() {
         mLabel = null;
-        updateForLabel();
-        updateView();
+        // 确保在主线程中更新UI
+        if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            updateForLabel();
+            updateView();
+        } else {
+            // 在后台线程中，使用Handler切换到主线程
+            mMainHandler.post(() -> {
+                updateForLabel();
+                updateView();
+            });
+        }
     }
 
     @Override
@@ -1279,8 +1865,17 @@ public class DownloadsScene extends ToolbarScene
         }
 
         mLabel = to;
-        updateForLabel();
-        updateView();
+        // 确保在主线程中更新UI
+        if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            updateForLabel();
+            updateView();
+        } else {
+            // 在后台线程中，使用Handler切换到主线程
+            mMainHandler.post(() -> {
+                updateForLabel();
+                updateView();
+            });
+        }
     }
 
     @Override
@@ -1289,14 +1884,64 @@ public class DownloadsScene extends ToolbarScene
             return;
         }
         if (mAdapter != null) {
-            mAdapter.notifyItemRemoved(listIndexInPage(position));
+            // 确保在主线程中更新UI
+            if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+                mAdapter.notifyItemRemoved(listIndexInPage(position));
+                updateView();
+            } else {
+                // 在后台线程中，使用Handler切换到主线程
+                mMainHandler.post(() -> {
+                    if (mAdapter != null) {
+                        mAdapter.notifyItemRemoved(listIndexInPage(position));
+                    }
+                    updateView();
+                });
+            }
         }
-        updateView();
     }
 
     @Override
     public void onUpdateLabels() {
-        // TODO
+        // 确保在主线程执行UI更新
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            SimpleHandler.getInstance().post(this::onUpdateLabels);
+            return;
+        }
+        
+        // 更新标签相关的UI
+        updateLabelTabs();
+        
+        // 刷新当前显示的列�?
+        if (mAdapter != null) {
+            mAdapter.notifyDataSetChanged();
+        }
+        
+        // 更新视图状�?
+        updateView();
+    }
+    
+    /**
+     * 更新标签页显�?
+     */
+    private void updateLabelTabs() {
+        if (mDownloadManager == null) {
+            return;
+        }
+        
+        // 获取所有标�?
+        List<DownloadLabel> labels = mDownloadManager.getLabelList();
+        
+        // 更新标签适配�?
+        if (mLabelAdapter != null) {
+            mLabelAdapter.notifyDataSetChanged();
+        }
+        
+        // 如果当前选中的标签被删除了，切换到默认标�?
+        if (mCurrentLabel != null && !mDownloadManager.containLabel(mCurrentLabel)) {
+            mCurrentLabel = null;
+            mLabel = null;
+            onInit();
+        }
     }
 
     @Nullable
@@ -1363,23 +2008,26 @@ public class DownloadsScene extends ToolbarScene
 
 
     private static void deleteFileAsync(UniFile... files) {
-        new AsyncTask<UniFile, Void, Void>() {
-            @Override
-            protected Void doInBackground(UniFile... params) {
-                for (UniFile file : params) {
-                    if (file != null) {
-                        file.delete();
-                    }
-                }
-                return null;
-            }
-        }.executeOnExecutor(IoThreadPoolExecutor.Companion.getInstance(), files);
+        Context context = EhApplication.getInstance();
+        DeleteFilesTask task = new DeleteFilesTask(context, files);
+        com.hippo.ehviewer.BackgroundTaskManager.getInstance().submitBackgroundTask(task);
     }
 
     @Override
     public void onClickTitle() {
         if (!mSearchMode) {
             enterSearchMode(true);
+            return;
+        }
+
+        if (mSearchBar != null) {
+            int state = mSearchBar.getState();
+            if (state != SearchBar.STATE_SEARCH_LIST) {
+                mSearchBar.setState(SearchBar.STATE_SEARCH_LIST, true);
+            } else {
+                // 如果已经是搜索列表状态，则重复点击隐�?显示
+                mSearchBar.toggleSuggestionsList();
+            }
         }
     }
 
@@ -1390,7 +2038,9 @@ public class DownloadsScene extends ToolbarScene
 
     @Override
     public void onClickRightIcon() {
-        mSearchBar.applySearch(true);
+        if (mSearchBar != null) {
+            mSearchBar.applySearch(true);
+        }
     }
 
     @Override
@@ -1401,9 +2051,16 @@ public class DownloadsScene extends ToolbarScene
 
     @Override
     public void onApplySearch(String query) {
+        // 检查mSearchBar是否为空，避免空指针异常
+        if (mSearchBar == null) {
+            Log.d("DownloadsScene", "onApplySearch: mSearchBar为null，可能对话框已关闭");
+            return;
+        }
+        
         searchKey = query;
         mSearchBar.hideKeyBoard();
         searching = true;
+        isFilteringOrSearching = true;  // 标记进入搜索状�?
         startSearching();
     }
 
@@ -1413,13 +2070,16 @@ public class DownloadsScene extends ToolbarScene
             mRecyclerView.setVisibility(View.GONE);
         }
 
-        if (mSearchMode) {
+        if (mSearchMode && mSearchBar != null) {
             mSearchMode = false;
+            isFilteringOrSearching = false;  // 退出搜索模式时清除标记
             mSearchBar.setTitle(searchKey);
             mSearchBar.setState(SearchBar.STATE_NORMAL);
         }
 
-        mSearchDialog.dismiss();
+        if (mSearchDialog != null) {
+            mSearchDialog.dismiss();
+        }
 
         updateForLabel();
 
@@ -1436,7 +2096,8 @@ public class DownloadsScene extends ToolbarScene
             mRecyclerView.setVisibility(View.GONE);
         }
 
-        DownloadListInfosExecutor executor = new DownloadListInfosExecutor(mBackList, mDownloadManager);
+        // 使用当前列表而不是原始列表进行过滤和排序
+        DownloadListInfosExecutor executor = new DownloadListInfosExecutor(mList, mDownloadManager);
 
         executor.setDownloadSearchingListener(this);
 
@@ -1444,16 +2105,21 @@ public class DownloadsScene extends ToolbarScene
     }
 
     private void updateAdapter() {
-        // 检查 Fragment 是否已附加，如果未附加则延迟创建适配器
+        // 检�?Fragment 是否已附加，如果未附加则延迟创建适配�?
         if (!isAdded()) {
             return;
         }
         mOriginalAdapter = new DownloadAdapter(this, this);
         mOriginalAdapter.setHasStableIds(true);
-        // 避免重复创建包装适配器，直接使用原始适配器
+        // 避免重复创建包装适配器，直接使用原始适配�?
         mAdapter = mOriginalAdapter;
         if (mRecyclerView != null) {
             mRecyclerView.setAdapter(mAdapter);
+        }
+        // 同步分页监听器持有的适配器与 RecyclerView，避免换适配器后页码点击无效
+        if (myPageChangeListener != null) {
+            myPageChangeListener.setAdapter(mOriginalAdapter);
+            myPageChangeListener.setRecyclerView(mRecyclerView);
         }
     }
 
@@ -1462,7 +2128,10 @@ public class DownloadsScene extends ToolbarScene
         if (mSearchMode) {
             mSearchMode = false;
         }
-        mSearchBar.setState(SearchBar.STATE_NORMAL, true);
+        // 防止空指针异�?
+        if (mSearchBar != null) {
+            mSearchBar.setState(SearchBar.STATE_NORMAL, true);
+        }
     }
 
     @Override
@@ -1488,28 +2157,52 @@ public class DownloadsScene extends ToolbarScene
 
     @Override
     public void onDownloadSearchSuccess(List<DownloadInfo> list) {
-        // 检查 Fragment 是否已附加，如果未附加则忽略回调
+        // 检�?Fragment 是否已附加，如果未附加则忽略回调
         if (!isAdded()) {
+            Log.w("DownloadsScene", "onDownloadSearchSuccess: Fragment未附加，忽略回调");
             return;
         }
+        
+        Log.d("DownloadsScene", "onDownloadSearchSuccess: 收到回调，列表大�?" + list.size());
         mList = list;
+        // 过滤或排序后重置分页到第一页，重新初始化分页指示器
+        indexPage = 1;
+        needInitPage = true;
+        doNotScroll = false;
         updateAdapter();
+        updatePaginationIndicator(true);
+        updateTitle();
         mProgressView.setVisibility(View.GONE);
         if (mRecyclerView != null) {
             mRecyclerView.setVisibility(View.VISIBLE);
         }
         searching = false;
         queryUnreadSpiderInfo();
+        
+        // 打印前几个项目的排序信息用于调试
+        if (list != null && list.size() > 0) {
+            Log.d("DownloadsScene", "onDownloadSearchSuccess: 排序后的�?个项�?");
+            for (int i = 0; i < Math.min(5, list.size()); i++) {
+                DownloadInfo info = list.get(i);
+                Log.d("DownloadsScene", "  [" + i + "] ID=" + info.gid + ", 标题=" + info.title + ", 时间=" + info.time);
+            }
+        }
     }
 
     @Override
     public void onDownloadListHandleSuccess(List<DownloadInfo> list) {
-        // 检查 Fragment 是否已附加，如果未附加则忽略回调
+        // 检�?Fragment 是否已附加，如果未附加则忽略回调
         if (!isAdded()) {
             return;
         }
         mList = list;
+        // 处理列表成功后同样重置分页并刷新指示�?
+        indexPage = 1;
+        needInitPage = true;
+        doNotScroll = false;
         updateAdapter();
+        updatePaginationIndicator(true);
+        updateTitle();
         mProgressView.setVisibility(View.GONE);
         if (mRecyclerView != null) {
             mRecyclerView.setVisibility(View.VISIBLE);
@@ -1519,9 +2212,15 @@ public class DownloadsScene extends ToolbarScene
 
     @Override
     public void onDownloadSearchFailed(List<DownloadInfo> list) {
-        Toast.makeText(getEHContext(), R.string.download_searching_failed, Toast.LENGTH_LONG).show();
+        UiThreadHelper.showToastSafely(getEHContext(), R.string.download_searching_failed, Toast.LENGTH_LONG);
         mList = list;
+        // 异常时也重置分页，避免页码停留在无效�?
+        indexPage = 1;
+        needInitPage = true;
+        doNotScroll = false;
         updateAdapter();
+        updatePaginationIndicator(true);
+        updateTitle();
         mProgressView.setVisibility(View.GONE);
         if (mRecyclerView != null) {
             mRecyclerView.setVisibility(View.VISIBLE);
@@ -1653,7 +2352,7 @@ public class DownloadsScene extends ToolbarScene
         } catch (Exception e) {
             Context context = getEHContext();
             if (context != null) {
-                Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show();
+                UiThreadHelper.showToastSafely(context, R.string.import_archive_failed, Toast.LENGTH_SHORT);
             }
         }
     }
@@ -1681,19 +2380,19 @@ public class DownloadsScene extends ToolbarScene
             Log.d(TAG, "Successfully obtained persistent URI permission for: " + uri);
         } catch (SecurityException e) {
             Log.e(TAG, "Failed to obtain persistent URI permission for: " + uri, e);
-            Toast.makeText(context, R.string.archive_permission_lost, Toast.LENGTH_LONG).show();
+            UiThreadHelper.showToastSafely(context, R.string.archive_permission_lost, Toast.LENGTH_LONG);
             return;
         } catch (Exception e) {
             Log.e(TAG, "Unexpected error when obtaining URI permission for: " + uri, e);
-            Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show();
+            UiThreadHelper.showToastSafely(context, R.string.import_archive_failed, Toast.LENGTH_SHORT);
             return;
         }
 
         // Show processing dialog
-        Toast.makeText(context, R.string.import_archive_processing, Toast.LENGTH_LONG).show();
+        UiThreadHelper.showToastSafely(context, R.string.import_archive_processing, Toast.LENGTH_LONG);
 
         // Process the archive file in background
-        new Thread(() -> processArchiveFile(uri)).start();
+        ExecutorManager.getBackgroundExecutor().execute(() -> processArchiveFile(uri));
     }
 
     private void processArchiveFile(Uri uri) {
@@ -1707,14 +2406,14 @@ public class DownloadsScene extends ToolbarScene
             try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
                 if (inputStream == null) {
                     runOnUiThread(() ->
-                            Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show()
+                            UiThreadHelper.showToastSafely(context, R.string.import_archive_failed, Toast.LENGTH_SHORT)
                     );
                     return;
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Cannot access file even with persistent permission", e);
                 runOnUiThread(() ->
-                        Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show()
+                        UiThreadHelper.showToastSafely(context, R.string.import_archive_failed, Toast.LENGTH_SHORT)
                 );
                 return;
             }
@@ -1830,22 +2529,32 @@ public class DownloadsScene extends ToolbarScene
                 return;
             }
 
-            // Delete
-            if (null != mDownloadManager) {
+            boolean checked = mBuilder.isChecked();
+            Settings.putRemoveImageFiles(checked);
+
+            // Remove from download list and move to recycle bin
+            if (mDownloadManager != null) {
                 mDownloadManager.deleteDownload(mGalleryInfo.gid);
             }
 
-            // Delete image files
-            boolean checked = mBuilder.isChecked();
-            Settings.putRemoveImageFiles(checked);
-            if (checked) {
-                // Remove download path
-                EhDB.removeDownloadDirname(mGalleryInfo.gid);
-                // Delete file
-                UniFile file = getGalleryDownloadDir(mGalleryInfo);
-                deleteFileAsync(file);
-            }
+            // When user selects delete, downloads are already moved to recycle bin by DownloadManager
+            // 'remove image files' setting means the user wants to quickly inline clear later.
         }
+    }
+
+    private void permanentlyDeleteGallery(LocalGalleryInfo galleryInfo, String displayTitle) {
+        Context context = getEHContext();
+        if (context == null || galleryInfo == null) {
+            return;
+        }
+
+        Toast.makeText(context, getString(R.string.recycle_bin_delete_permanent_confirm, displayTitle), Toast.LENGTH_SHORT).show();
+
+        LocalGalleryManager.getInstance(context).permanentlyDeleteGallery(galleryInfo, (current, total, detail) -> {
+            if (current >= total) {
+                Toast.makeText(context, R.string.recycle_bin_delete_permanent_success, Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     private class DeleteRangeDialogHelper implements DialogInterface.OnClickListener {
@@ -1872,27 +2581,60 @@ public class DownloadsScene extends ToolbarScene
                 mRecyclerView.outOfCustomChoiceMode();
             }
 
-            // Delete
-            if (null != mDownloadManager) {
-                mDownloadManager.deleteRangeDownload(mGidList);
-            }
-
-            // Delete image files
+            // 图片文件删除选项
             boolean checked = mBuilder.isChecked();
             Settings.putRemoveImageFiles(checked);
-            if (checked) {
-                UniFile[] files = new UniFile[mDownloadInfoList.size()];
-                int i = 0;
-                for (DownloadInfo info : mDownloadInfoList) {
-                    // Remove download path
-                    EhDB.removeDownloadDirname(info.gid);
-                    // Put file
-                    files[i] = getGalleryDownloadDir(info);
-                    i++;
+
+            // 少量删除直接原逻辑（避免开新线程开销�?
+            if (mDownloadInfoList.size() <= 5) {
+                if (mDownloadManager != null) {
+                    mDownloadManager.deleteRangeDownload(mGidList);
                 }
-                // Delete file
-                deleteFileAsync(files);
+                if (checked) {
+                    // item moved to recycle bin already; we keep permanent delete to user action in recycle bin UI
+                }
+                return;
             }
+
+            // 多个项目删档用后台任�?
+            Context context = getActivity2();
+            if (context == null) {
+                return;
+            }
+
+            Toast.makeText(context, R.string.download_remove_dialog_title, Toast.LENGTH_SHORT).show();
+
+            DeleteRangeDownloadTask task = new DeleteRangeDownloadTask(context, mDownloadManager, mGidList, new Runnable() {
+                @Override
+                public void run() {
+                    refreshDownloadListAfterDelete();
+                }
+            });
+
+            task.setProgressListener(new BackgroundTask.ProgressListener() {
+                @Override
+                public void onProgressChanged(int progress, String detail) {
+                    // Progress updates handled via notification
+                }
+
+                @Override
+                public void onProgressChanged(int current, int total, String detail) {
+                    // Progress updates handled via notification
+                }
+
+                @Override
+                public void onCompleted() {
+                    // Handled by onCompletedCallback
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    refreshDownloadListAfterDelete();
+                }
+            });
+
+            com.hippo.ehviewer.BackgroundTaskManager.getInstance().submitBackgroundTask(task);
+            Toast.makeText(context, R.string.background_task_submitted, Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -1940,13 +2682,13 @@ public class DownloadsScene extends ToolbarScene
 //            RecyclerView.ViewHolder holder = mRecyclerView.getChildViewHolder(mRecyclerView.getChildAt(i));
 //            if (holder instanceof DownloadAdapter.DownloadHolder) {
 //                DownloadAdapter.DownloadHolder downloadHolder = (DownloadAdapter.DownloadHolder) holder;
-//                // thumb 始终可见，拖拽功能已直接附加到thumb上
+//                // thumb 始终可见，拖拽功能已直接附加到thumb�?
 //                downloadHolder.thumb.setVisibility(View.VISIBLE);
 //            }
 //        }
 //    }
 
-    private class DownloadChoiceListener implements MyEasyRecyclerView.CustomChoiceListener {
+    private class DownloadChoiceListener implements EasyRecyclerView.CustomChoiceListener {
 
         @Override
         public void onIntoCustomChoice(EasyRecyclerView view) {
@@ -2003,12 +2745,451 @@ public class DownloadsScene extends ToolbarScene
                 }
             }
         }
+        // 如果没有应用状态过滤或排序，直接更新界�?
         if (mAdapter != null) {
             mAdapter.notifyDataSetChanged();
         }
         updateTitle();
-        updatePaginationIndicator();
+        updatePaginationIndicator(true); // 筛选时强制重新初始�?
         updateView();
         queryUnreadSpiderInfo();
+    }
+
+    private void showSortFilterDialog() {
+        Context context = getEHContext();
+        if (context == null) {
+            return;
+        }
+
+        // 如果弹窗已经存在，直接显�?
+        if (mSortFilterDialog != null && mSortFilterDialog.isShowing()) {
+            return;
+        }
+
+        // 创建弹窗视图 - 使用新的布局
+        View dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_sort_filter_v2, null);
+        View advancedFilterToggleRow = dialogView.findViewById(R.id.advanced_filter_toggle_row);
+        TextView advancedFilterToggleIcon = dialogView.findViewById(R.id.advanced_filter_toggle_icon);
+        View advancedFilterContentContainer = dialogView.findViewById(R.id.advanced_filter_content_container);
+
+        // 高级筛选面板默认折叠
+        setSectionExpanded(advancedFilterContentContainer, advancedFilterToggleIcon, false);
+        advancedFilterToggleRow.setOnClickListener(v -> toggleSection(advancedFilterContentContainer, advancedFilterToggleIcon));
+        
+        // 获取CategoryTable
+        DownloadCategoryTable categoryTable = dialogView.findViewById(R.id.category_table);
+        
+        // 初始化RecyclerView和范围输入
+        RecyclerView statusRecyclerView = dialogView.findViewById(R.id.status_recycler_view);
+        RecyclerView sortRecyclerView = dialogView.findViewById(R.id.sort_recycler_view);
+        EditText timeFromInput = dialogView.findViewById(R.id.filter_time_from_input);
+        EditText timeToInput = dialogView.findViewById(R.id.filter_time_to_input);
+        EditText sizeFromInput = dialogView.findViewById(R.id.filter_size_from_input);
+        EditText sizeToInput = dialogView.findViewById(R.id.filter_size_to_input);
+        Button pickTimeFromButton = dialogView.findViewById(R.id.pick_time_from_button);
+        Button pickTimeToButton = dialogView.findViewById(R.id.pick_time_to_button);
+        CheckBox duplicateOnlyCheckbox = dialogView.findViewById(R.id.filter_duplicate_only_checkbox);
+        
+        // 竖屏单列，横屏双列平铺
+        int spanCount = context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ? 2 : 1;
+        statusRecyclerView.setLayoutManager(new GridLayoutManager(context, spanCount));
+        sortRecyclerView.setLayoutManager(new GridLayoutManager(context, spanCount));
+        statusRecyclerView.setNestedScrollingEnabled(false);
+        sortRecyclerView.setNestedScrollingEnabled(false);
+
+        // 准备状态数据（去除全部选项�?
+        List<String> statusItems = new ArrayList<>();
+        List<Integer> statusIds = new ArrayList<>();
+        statusItems.add(getString(R.string.download_state_downloaded));
+        statusIds.add(R.id.download_done);
+        statusItems.add(getString(R.string.download_state_none));
+        statusIds.add(R.id.not_started);
+        statusItems.add(getString(R.string.download_state_wait));
+        statusIds.add(R.id.waiting);
+        statusItems.add(getString(R.string.download_state_downloading));
+        statusIds.add(R.id.downloading);
+        statusItems.add(getString(R.string.download_state_failed));
+        statusIds.add(R.id.failed);
+
+        // 准备排序数据
+        List<String> sortItems = new ArrayList<>();
+        List<Integer> sortIds = new ArrayList<>();
+        sortItems.add(getString(R.string.default_sort));
+        sortIds.add(R.id.sort_by_default);
+        sortItems.add(getString(R.string.sort_by_gallery_id_asc));
+        sortIds.add(R.id.sort_by_gallery_id_asc);
+        sortItems.add(getString(R.string.sort_by_gallery_id_desc));
+        sortIds.add(R.id.sort_by_gallery_id_desc);
+        sortItems.add(getString(R.string.sort_by_create_time_asc));
+        sortIds.add(R.id.sort_by_create_time_asc);
+        sortItems.add(getString(R.string.sort_by_create_time_desc));
+        sortIds.add(R.id.sort_by_create_time_desc);
+        sortItems.add(getString(R.string.sort_by_rating_asc));
+        sortIds.add(R.id.sort_by_rating_asc);
+        sortItems.add(getString(R.string.sort_by_rating_desc));
+        sortIds.add(R.id.sort_by_rating_desc);
+        sortItems.add(getString(R.string.sort_by_name_asc));
+        sortIds.add(R.id.sort_by_name_asc);
+        sortItems.add(getString(R.string.sort_by_name_desc));
+        sortIds.add(R.id.sort_by_name_desc);
+        sortItems.add(getString(R.string.sort_by_file_size_asc));
+        sortIds.add(R.id.sort_by_file_size_asc);
+        sortItems.add(getString(R.string.sort_by_file_size_desc));
+        sortIds.add(R.id.sort_by_file_size_desc);
+
+        // 初始化适配�?
+        mStatusAdapter = new CheckboxAdapter(statusItems, statusIds);
+        mSortAdapter = new CheckboxAdapter(sortItems, sortIds);
+        
+        // 设置互斥选择 - 状态改为多选，排序保持互斥
+        mStatusAdapter.setMutuallyExclusive(false);
+        mSortAdapter.setMutuallyExclusive(true);
+
+        // 设置选择变更监听�?
+        mStatusAdapter.setOnSelectionChangedListener(selectedItems -> {
+            Log.d("DownloadsScene", "状态选择已变�? " + selectedItems);
+            mSelectedStatuses.clear();
+            mSelectedStatuses.addAll(selectedItems);
+        });
+        
+        mSortAdapter.setOnSelectionChangedListener(selectedItems -> {
+            Log.d("DownloadsScene", "排序选择已变�? " + selectedItems);
+            mSelectedSorts.clear();
+            mSelectedSorts.addAll(selectedItems);
+        });
+
+        // 设置适配�?
+        statusRecyclerView.setAdapter(mStatusAdapter);
+        sortRecyclerView.setAdapter(mSortAdapter);
+
+        // 设置CategoryTable的选中状�?
+        if (mSelectedCategories != null && !mSelectedCategories.isEmpty()) {
+            // 使用新的DownloadCategoryTable，直接设置选中的分�?
+            categoryTable.setSelectedCategories(mSelectedCategories);
+        } else {
+            // 默认全�?- 确保所有按钮都是亮起的
+            mSelectedCategories = new HashSet<>();
+            mSelectedCategories.add(EhUtils.ALL_CATEGORY);
+            categoryTable.setSelectedCategories(mSelectedCategories);
+        }
+
+        // 设置默认选中�?
+        if (mSelectedStatuses.isEmpty()) {
+            // 默认全选所有状�?
+            mSelectedStatuses.add(R.id.download_done);
+            mSelectedStatuses.add(R.id.not_started);
+            mSelectedStatuses.add(R.id.waiting);
+            mSelectedStatuses.add(R.id.downloading);
+            mSelectedStatuses.add(R.id.failed);
+        }
+        if (mSelectedSorts.isEmpty()) {
+            mSelectedSorts.add(R.id.sort_by_default);
+        }
+
+        timeFromInput.setText(mFilterTimeFromInput);
+        timeToInput.setText(mFilterTimeToInput);
+        sizeFromInput.setText(mFilterSizeFromInput);
+        sizeToInput.setText(mFilterSizeToInput);
+        duplicateOnlyCheckbox.setChecked(mFilterDuplicateOnly);
+
+        pickTimeFromButton.setOnClickListener(v -> showDateTimePicker(timeFromInput));
+        pickTimeToButton.setOnClickListener(v -> showDateTimePicker(timeToInput));
+
+        // 使用post方法延迟设置选中项，避免在RecyclerView计算布局时调�?
+        dialogView.post(() -> {
+            mStatusAdapter.setSelectedItems(mSelectedStatuses);
+            mSortAdapter.setSelectedItems(mSelectedSorts);
+        });
+
+        // 创建弹窗
+        mSortFilterDialog = new AlertDialog.Builder(context)
+                .setTitle(R.string.advanced_filter)
+                .setView(dialogView)
+                .create();
+
+        // 设置按钮点击事件
+        Button resetButton = dialogView.findViewById(R.id.reset_button);
+        Button applyButton = dialogView.findViewById(R.id.apply_button);
+        Button selectAllStatusButton = dialogView.findViewById(R.id.select_all_status_button);
+        Button selectNoneStatusButton = dialogView.findViewById(R.id.select_none_status_button);
+        
+        // 全选按钮点击事�?
+        selectAllStatusButton.setOnClickListener(v -> {
+            mSelectedStatuses.clear();
+            mSelectedStatuses.add(R.id.download_done);
+            mSelectedStatuses.add(R.id.not_started);
+            mSelectedStatuses.add(R.id.waiting);
+            mSelectedStatuses.add(R.id.downloading);
+            mSelectedStatuses.add(R.id.failed);
+            mStatusAdapter.setSelectedItems(mSelectedStatuses);
+        });
+        
+        // 全不选按钮点击事�?
+        selectNoneStatusButton.setOnClickListener(v -> {
+            mSelectedStatuses.clear();
+            mStatusAdapter.setSelectedItems(mSelectedStatuses);
+        });
+
+        resetButton.setOnClickListener(v -> {
+            // 重置所有选择
+            mSelectedCategories.clear();
+            mSelectedStatuses.clear();
+            mSelectedSorts.clear();
+
+            mSelectedCategories.add(EhUtils.ALL_CATEGORY);
+            // 重置为全选所有状�?
+            mSelectedStatuses.add(R.id.download_done);
+            mSelectedStatuses.add(R.id.not_started);
+            mSelectedStatuses.add(R.id.waiting);
+            mSelectedStatuses.add(R.id.downloading);
+            mSelectedStatuses.add(R.id.failed);
+            mSelectedSorts.add(R.id.sort_by_default);
+
+            mFilterTimeFrom = null;
+            mFilterTimeTo = null;
+            mFilterSizeFrom = null;
+            mFilterSizeTo = null;
+            mFilterDuplicateOnly = false;
+            mFilterTimeFromInput = "";
+            mFilterTimeToInput = "";
+            mFilterSizeFromInput = "";
+            mFilterSizeToInput = "";
+            timeFromInput.setText("");
+            timeToInput.setText("");
+            sizeFromInput.setText("");
+            sizeToInput.setText("");
+            duplicateOnlyCheckbox.setChecked(false);
+
+            // 重置CategoryTable - 确保所有按钮都是亮起的
+            categoryTable.setSelectedCategories(mSelectedCategories);
+
+            // 使用post方法延迟设置选中项，避免在RecyclerView计算布局时调�?
+            dialogView.post(() -> {
+                mStatusAdapter.setSelectedItems(mSelectedStatuses);
+                mSortAdapter.setSelectedItems(mSelectedSorts);
+            });
+        });
+
+        applyButton.setOnClickListener(v -> {
+            mSelectedCategories = categoryTable.getSelectedCategories();
+            Log.d("DownloadsScene", "applySortAndFilter: 获取到的分类=" + mSelectedCategories);
+
+            String timeFromRaw = timeFromInput.getText() != null ? timeFromInput.getText().toString().trim() : "";
+            String timeToRaw = timeToInput.getText() != null ? timeToInput.getText().toString().trim() : "";
+            String sizeFromRaw = sizeFromInput.getText() != null ? sizeFromInput.getText().toString().trim() : "";
+            String sizeToRaw = sizeToInput.getText() != null ? sizeToInput.getText().toString().trim() : "";
+
+            Long parsedTimeFrom = parseTimeInput(timeFromRaw, false);
+            if (timeFromRaw.length() > 0 && parsedTimeFrom == null) {
+                Toast.makeText(context, R.string.download_filter_invalid_time, Toast.LENGTH_SHORT).show();
+                return;
+            }
+            Long parsedTimeTo = parseTimeInput(timeToRaw, true);
+            if (timeToRaw.length() > 0 && parsedTimeTo == null) {
+                Toast.makeText(context, R.string.download_filter_invalid_time, Toast.LENGTH_SHORT).show();
+                return;
+            }
+            if (parsedTimeFrom != null && parsedTimeTo != null && parsedTimeFrom > parsedTimeTo) {
+                Toast.makeText(context, R.string.download_filter_range_invalid, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            Long parsedSizeFrom = parseSizeInput(sizeFromRaw);
+            if (sizeFromRaw.length() > 0 && parsedSizeFrom == null) {
+                Toast.makeText(context, R.string.download_filter_invalid_size, Toast.LENGTH_SHORT).show();
+                return;
+            }
+            Long parsedSizeTo = parseSizeInput(sizeToRaw);
+            if (sizeToRaw.length() > 0 && parsedSizeTo == null) {
+                Toast.makeText(context, R.string.download_filter_invalid_size, Toast.LENGTH_SHORT).show();
+                return;
+            }
+            if (parsedSizeFrom != null && parsedSizeTo != null && parsedSizeFrom > parsedSizeTo) {
+                Toast.makeText(context, R.string.download_filter_range_invalid, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            mFilterTimeFrom = parsedTimeFrom;
+            mFilterTimeTo = parsedTimeTo;
+            mFilterSizeFrom = parsedSizeFrom;
+            mFilterSizeTo = parsedSizeTo;
+            mFilterDuplicateOnly = duplicateOnlyCheckbox.isChecked();
+            mFilterTimeFromInput = timeFromRaw;
+            mFilterTimeToInput = timeToRaw;
+            mFilterSizeFromInput = sizeFromRaw;
+            mFilterSizeToInput = sizeToRaw;
+
+            Log.d("DownloadsScene", "applyButton clicked: 应用过滤和排序");
+            applySortAndFilter();
+            mSortFilterDialog.dismiss();
+        });
+
+        mSortFilterDialog.show();
+    }
+
+    private void applySortAndFilter() {
+        // 添加日志
+        Log.d("DownloadsScene", "applySortAndFilter: 开始应用过滤和排序");
+        
+        // 应用分类过滤
+        Set<Integer> selectedCategories = new HashSet<>();
+        Integer selectedStatus = R.id.all;
+        Integer selectedSort = R.id.sort_by_default;
+        
+        if (mSelectedCategories != null && !mSelectedCategories.isEmpty()) {
+            selectedCategories.addAll(mSelectedCategories);
+            Log.d("DownloadsScene", "applySortAndFilter: 选中的分类ID = " + selectedCategories);
+        } else {
+            // 如果没有选择分类，默认为全部
+            selectedCategories.add(EhUtils.ALL_CATEGORY);
+        }
+        
+        // 状态现在是多选的，不需要取第一个，直接传递集�?
+        Log.d("DownloadsScene", "applySortAndFilter: 选中的状态ID集合 = " + mSelectedStatuses);
+        
+        if (!mSelectedSorts.isEmpty()) {
+            // 取第一个选中的排序（现在是互斥的，只会有一个）
+            selectedSort = mSelectedSorts.iterator().next();
+            Log.d("DownloadsScene", "applySortAndFilter: 选中的排序ID = " + selectedSort);
+        }
+        
+        // 检查是否只选择了ALL_CATEGORY（即全选状态）
+        boolean isAllCategories = selectedCategories.size() == 1 && selectedCategories.contains(EhUtils.ALL_CATEGORY);
+        
+        // 如果需要应用任何过滤或排序
+        boolean hasStatusFilter = !mSelectedStatuses.isEmpty() && mSelectedStatuses.size() < 5; // 5是所有状态的数量
+        boolean hasRangeFilter = mFilterTimeFrom != null || mFilterTimeTo != null
+                || mFilterSizeFrom != null || mFilterSizeTo != null;
+        boolean hasDuplicateFilter = mFilterDuplicateOnly;
+        if (!isAllCategories || hasStatusFilter || selectedSort != R.id.sort_by_default || hasRangeFilter || hasDuplicateFilter) {
+            Log.d("DownloadsScene", "applySortAndFilter: 需要应用过滤或排序");
+            isFilteringOrSearching = true;  // 标记进入筛选状态
+            mProgressView.setVisibility(View.VISIBLE);
+            if (mRecyclerView != null) {
+                mRecyclerView.setVisibility(View.GONE);
+            }
+            
+            // 创建执行器并应用过滤和排序
+            DownloadListInfosExecutor executor = new DownloadListInfosExecutor(mBackList, mDownloadManager);
+            executor.setDownloadSearchingListener(this);
+            
+            // 同时应用分类过滤、状态过滤和排序（含时间/大小范围）
+            Log.d("DownloadsScene", "applySortAndFilter: 调用executeFilterAndSort, categories=" + selectedCategories + ", statuses=" + mSelectedStatuses + ", sort=" + selectedSort);
+            executor.executeFilterAndSort(selectedCategories, mSelectedStatuses, selectedSort,
+                    mFilterTimeFrom, mFilterTimeTo, mFilterSizeFrom, mFilterSizeTo, mFilterDuplicateOnly);
+        } else {
+            Log.d("DownloadsScene", "applySortAndFilter: 不需要任何过滤或排序，使用原始列表");
+            isFilteringOrSearching = false;  // 标记退出筛选状态
+            // 不需要任何过滤或排序，直接使用原始列表
+            mList = new ArrayList<>(mBackList);
+            updateAdapter();
+            updateTitle();
+            updatePaginationIndicator(true);
+            updateView();
+            queryUnreadSpiderInfo();
+        }
+    }
+
+    /**
+     * 解析时间输入字符串为毫秒时间戳。
+     * 支持格式: "yyyy-MM-dd" 或 "yyyy-MM-dd HH:mm"
+     * @param input 用户输入
+     * @param isEnd 若为 true 且仅输入日期，则自动补全为当天结束时间 23:59:59.999
+     */
+    @Nullable
+    private Long parseTimeInput(String input, boolean isEnd) {
+        if (input == null || input.trim().isEmpty()) {
+            return null;
+        }
+        String s = input.trim();
+        String[] formats = {"yyyy-MM-dd HH:mm", "yyyy-MM-dd"};
+        for (String fmt : formats) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat(fmt, Locale.getDefault());
+                sdf.setLenient(false);
+                Date d = sdf.parse(s);
+                if (d != null) {
+                    long ts = d.getTime();
+                    if (isEnd && fmt.equals("yyyy-MM-dd")) {
+                        ts += 24L * 60 * 60 * 1000 - 1; // 补全到当天末尾
+                    }
+                    return ts;
+                }
+            } catch (ParseException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private void showDateTimePicker(@NonNull EditText targetInput) {
+        Context context = getEHContext();
+        if (context == null) {
+            return;
+        }
+
+        final Calendar calendar = Calendar.getInstance();
+        DatePickerDialog datePickerDialog = new DatePickerDialog(
+                context,
+                (view, year, month, dayOfMonth) -> {
+                    calendar.set(Calendar.YEAR, year);
+                    calendar.set(Calendar.MONTH, month);
+                    calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth);
+
+                    TimePickerDialog timePickerDialog = new TimePickerDialog(
+                            context,
+                            (timeView, hourOfDay, minute) -> {
+                                calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
+                                calendar.set(Calendar.MINUTE, minute);
+                                calendar.set(Calendar.SECOND, 0);
+                                calendar.set(Calendar.MILLISECOND, 0);
+
+                                SimpleDateFormat outputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());
+                                targetInput.setText(outputFormat.format(calendar.getTime()));
+                            },
+                            calendar.get(Calendar.HOUR_OF_DAY),
+                            calendar.get(Calendar.MINUTE),
+                            true
+                    );
+                    timePickerDialog.show();
+                },
+                calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH),
+                calendar.get(Calendar.DAY_OF_MONTH)
+        );
+        datePickerDialog.show();
+    }
+
+    /**
+     * 解析大小输入字符串为字节数。
+     * 支持: 纯数字(视为 MB)，或数字+单位(B/KB/MB/GB)。
+     */
+    @Nullable
+    private Long parseSizeInput(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            return null;
+        }
+        String s = input.trim().toUpperCase(Locale.ROOT);
+        long multiplier = 1024L * 1024L; // 默认 MB
+        String numPart = s;
+        if (s.endsWith("GB")) {
+            multiplier = 1024L * 1024L * 1024L;
+            numPart = s.substring(0, s.length() - 2).trim();
+        } else if (s.endsWith("MB")) {
+            multiplier = 1024L * 1024L;
+            numPart = s.substring(0, s.length() - 2).trim();
+        } else if (s.endsWith("KB")) {
+            multiplier = 1024L;
+            numPart = s.substring(0, s.length() - 2).trim();
+        } else if (s.endsWith("B")) {
+            multiplier = 1L;
+            numPart = s.substring(0, s.length() - 1).trim();
+        }
+        try {
+            double num = Double.parseDouble(numPart);
+            if (num < 0) return null;
+            return (long) (num * multiplier);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/app/src/main/res/layout/dialog_sort_filter_v2.xml
+++ b/app/src/main/res/layout/dialog_sort_filter_v2.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:id="@+id/advanced_filter_toggle_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_border_rounded"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="44dp"
+        android:orientation="horizontal"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="8dp">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/advanced_filter"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/advanced_filter_toggle_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="+"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/advanced_filter_content_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:fillViewport="true"
+            android:layout_marginTop="8dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_category_filter_label"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <com.hippo.ehviewer.ui.scene.download.part.DownloadCategoryTable
+                android:id="@+id/category_table"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_status_filter_label"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/select_all_status_button"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="32dp"
+                    android:layout_weight="1"
+                    android:text="@string/select_all"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="12sp" />
+
+                <Button
+                    android:id="@+id/select_none_status_button"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="32dp"
+                    android:layout_weight="1"
+                    android:text="@string/deselect_all"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="12sp" />
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/status_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:background="@drawable/bg_border_rounded"
+                android:nestedScrollingEnabled="false"
+                android:padding="8dp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_sort_method_label"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/sort_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:background="@drawable/bg_border_rounded"
+                android:nestedScrollingEnabled="false"
+                android:padding="8dp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_time_range_filter_label"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
+
+                    <EditText
+                        android:id="@+id/filter_time_from_input"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/dialog_time_range_from_hint"
+                        android:inputType="text"
+                        android:maxLines="1" />
+
+                    <Button
+                        android:id="@+id/pick_time_from_button"
+                        style="@style/Widget.AppCompat.Button.Borderless"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:minWidth="0dp"
+                        android:text="@string/select_datetime_button" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
+
+                    <EditText
+                        android:id="@+id/filter_time_to_input"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/dialog_time_range_to_hint"
+                        android:inputType="text"
+                        android:maxLines="1" />
+
+                    <Button
+                        android:id="@+id/pick_time_to_button"
+                        style="@style/Widget.AppCompat.Button.Borderless"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:minWidth="0dp"
+                        android:text="@string/select_datetime_button" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_size_range_filter_label"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:orientation="horizontal">
+
+                <EditText
+                    android:id="@+id/filter_size_from_input"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/dialog_size_range_from_hint"
+                    android:inputType="text"
+                    android:maxLines="1" />
+
+                <EditText
+                    android:id="@+id/filter_size_to_input"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_weight="1"
+                    android:hint="@string/dialog_size_range_to_hint"
+                    android:inputType="text"
+                    android:maxLines="1" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_size_range_tip"
+                android:textColor="?android:textColorSecondary"
+                android:textSize="12sp" />
+
+            <CheckBox
+                android:id="@+id/filter_duplicate_only_checkbox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_filter_duplicate_only" />
+
+        </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/reset_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/reset"
+            android:textColor="?android:textColorPrimary" />
+
+        <Button
+            android:id="@+id/apply_button"
+            style="@style/Widget.AppCompat.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/apply" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/download_search_dialog_v2.xml
+++ b/app/src/main/res/layout/download_search_dialog_v2.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:gravity="center"
+                android:text="@string/dialog_search_download_title"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <com.hippo.ehviewer.widget.SearchBar
+                android:id="@+id/download_search_bar"
+                style="@style/CardView.Normal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:hint="@string/download_search_hint" />
+
+            <LinearLayout
+                android:id="@+id/advance_search_toggle_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_border_rounded"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:minHeight="44dp"
+                android:orientation="horizontal"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="8dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/dialog_search_options_label"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/advance_search_toggle_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="+"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advance_search_content_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="12dp"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <com.hippo.ehviewer.widget.AdvanceSearchTable
+                    android:id="@+id/advance_search_table"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/category_filter_toggle_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_border_rounded"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:minHeight="44dp"
+                android:orientation="horizontal"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="8dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/dialog_category_filter_label"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/category_filter_toggle_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="+"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/category_filter_content_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="12dp"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <com.hippo.ehviewer.ui.scene.download.part.DownloadCategoryTable
+                    android:id="@+id/category_table"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/dialog_sort_method_label"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/search_sort_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:background="@drawable/bg_border_rounded"
+                android:nestedScrollingEnabled="false"
+                android:padding="8dp" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <!-- 按钮区域 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/reset_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/reset"
+            android:textColor="?android:textColorPrimary" />
+
+        <Button
+            android:id="@+id/search_button"
+            style="@style/Widget.AppCompat.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/search"
+            android:layout_marginStart="8dp" />
+
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## 变更目标
将下载页搜索交互统一为可折叠面板，并完善排序联动逻辑，提升筛选效率与可用性。

## 切片范围（仅本功能）
- 更新下载场景搜索交互逻辑。
- 新增并接入搜索相关对话框布局：
  - `dialog_sort_filter_v2.xml`
  - `download_search_dialog_v2.xml`

## 说明
本 PR 为功能切片，不包含下载状态同步/后台任务等其它能力。

## 依赖
建议先合并 CI 修复 PR #2545（恢复 gradle wrapper），否则 GitHub Actions 可能在 `./gradlew` 阶段失败。

## 风险
中等：涉及下载场景 UI 与筛选交互，需要重点回归筛选、排序、重置等流程。
