### PR TITLE
feat(media): 增加 GIF/WebP 检测工具与单元测试

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/util/GifUtils.java
+++ b/app/src/main/java/com/hippo/ehviewer/util/GifUtils.java
@@ -1,0 +1,193 @@
+package com.hippo.ehviewer.util;
+
+import android.text.TextUtils;
+import com.hippo.lib.yorozuya.IOUtils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class GifUtils {
+
+    private static final int HEADER_SIZE = 6;
+    private static final int LSD_SIZE = 7;
+    private static final int EXTENSION_INTRODUCER = 0x21;
+    private static final int GRAPHICS_CONTROL_LABEL = 0xF9;
+    private static final int IMAGE_SEPARATOR = 0x2C;
+    private static final int TRAILER = 0x3B;
+    private static final int DEFAULT_FRAME_DELAY = 100;
+
+    private GifUtils() {
+    }
+
+    public static Boolean isAnimatedGifFile(String path) {
+        if (TextUtils.isEmpty(path)) {
+            return null;
+        }
+        File file = new File(path);
+        if (!file.exists() || !file.isFile()) {
+            return null;
+        }
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return isAnimatedGif(fis);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static boolean isAnimatedGif(InputStream is) throws IOException {
+        return getGifAnimationDuration(is) > 0;
+    }
+
+    public static Long getGifAnimationDuration(String path) {
+        if (TextUtils.isEmpty(path)) {
+            return null;
+        }
+        File file = new File(path);
+        if (!file.exists() || !file.isFile()) {
+            return null;
+        }
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return getGifAnimationDuration(fis);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static long getGifAnimationDuration(InputStream is) throws IOException {
+        if (is == null) {
+            return 0;
+        }
+
+        byte[] header = new byte[HEADER_SIZE];
+        if (readFully(is, header, 0, HEADER_SIZE) < HEADER_SIZE) {
+            return 0;
+        }
+        String signature = new String(header, "ASCII");
+        if (!"GIF89a".equals(signature) && !"GIF87a".equals(signature)) {
+            return 0;
+        }
+
+        byte[] lsd = new byte[LSD_SIZE];
+        if (readFully(is, lsd, 0, LSD_SIZE) < LSD_SIZE) {
+            return 0;
+        }
+
+        int packed = lsd[4] & 0xFF;
+        if ((packed & 0x80) != 0) {
+            int tableSize = 3 * (1 << ((packed & 0x07) + 1));
+            if (!skipFully(is, tableSize)) {
+                return 0;
+            }
+        }
+
+        int pendingDelay = -1;
+        int imageCount = 0;
+        long totalDelay = 0;
+
+        while (true) {
+            int block = is.read();
+            if (block == -1 || block == TRAILER) {
+                break;
+            }
+            if (block == IMAGE_SEPARATOR) {
+                imageCount++;
+                byte[] descriptor = new byte[9];
+                if (readFully(is, descriptor, 0, 9) < 9) {
+                    return 0;
+                }
+                int packedFields = descriptor[8] & 0xFF;
+                if ((packedFields & 0x80) != 0) {
+                    int localTableSize = 3 * (1 << ((packedFields & 0x07) + 1));
+                    if (!skipFully(is, localTableSize)) {
+                        return 0;
+                    }
+                }
+                if (is.read() == -1) {
+                    return 0;
+                }
+                if (!skipSubBlocks(is)) {
+                    return 0;
+                }
+                int frameDelay = pendingDelay >= 0 ? pendingDelay : DEFAULT_FRAME_DELAY;
+                totalDelay += frameDelay;
+                pendingDelay = -1;
+            } else if (block == EXTENSION_INTRODUCER) {
+                int label = is.read();
+                if (label == -1) {
+                    return 0;
+                }
+                if (label == GRAPHICS_CONTROL_LABEL) {
+                    int blockSize = is.read();
+                    if (blockSize == -1) {
+                        return 0;
+                    }
+                    byte[] blockData = new byte[blockSize];
+                    if (readFully(is, blockData, 0, blockSize) < blockSize) {
+                        return 0;
+                    }
+                    if (!skipSubBlocks(is)) {
+                        return 0;
+                    }
+                    if (blockSize >= 4) {
+                        int delay = ((blockData[2] & 0xFF) << 8) | (blockData[1] & 0xFF);
+                        if (delay <= 10) {
+                            delay = DEFAULT_FRAME_DELAY;
+                        }
+                        pendingDelay = delay;
+                    }
+                } else {
+                    if (!skipSubBlocks(is)) {
+                        return 0;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        return imageCount > 1 ? totalDelay : 0;
+    }
+
+    private static int readFully(InputStream is, byte[] buffer, int offset, int length)
+            throws IOException {
+        int read = 0;
+        while (read < length) {
+            int n = is.read(buffer, offset + read, length - read);
+            if (n == -1) {
+                break;
+            }
+            read += n;
+        }
+        return read;
+    }
+
+    private static boolean skipFully(InputStream is, long length) throws IOException {
+        while (length > 0) {
+            long skipped = is.skip(length);
+            if (skipped <= 0) {
+                int b = is.read();
+                if (b == -1) {
+                    return false;
+                }
+                skipped = 1;
+            }
+            length -= skipped;
+        }
+        return true;
+    }
+
+    private static boolean skipSubBlocks(InputStream is) throws IOException {
+        int blockSize;
+        do {
+            blockSize = is.read();
+            if (blockSize == -1) {
+                return false;
+            }
+            if (blockSize > 0 && !skipFully(is, blockSize)) {
+                return false;
+            }
+        } while (blockSize != 0);
+        return true;
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/util/WebpUtils.java
+++ b/app/src/main/java/com/hippo/ehviewer/util/WebpUtils.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Hippo Seven
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hippo.ehviewer.util;
+
+import android.text.TextUtils;
+import com.hippo.lib.yorozuya.IOUtils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class WebpUtils {
+
+    private static final int HEADER_SIZE = 30;
+    private static final int VP8X_CHUNK_SIZE = 10;
+    private static final int ANIMATION_FLAG = 0x02;
+
+    private WebpUtils() {
+    }
+
+    /**
+     * Detect if a local WebP file contains animation information.
+     *
+     * @param path local file path
+     * @return true if animated, false if static, null if the path cannot be inspected
+     */
+    public static Boolean isAnimatedWebpFile(String path) {
+        if (TextUtils.isEmpty(path)) {
+            return null;
+        }
+        File file = new File(path);
+        if (!file.exists() || !file.isFile()) {
+            return null;
+        }
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return isAnimatedWebp(fis);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Detect WebP animation from the beginning of a WebP image stream.
+     *
+     * @param is WebP input stream
+     * @return true if animated, false otherwise
+     * @throws IOException on stream errors
+     */
+    public static boolean isAnimatedWebp(InputStream is) throws IOException {
+        if (is == null) {
+            return false;
+        }
+
+        byte[] header = new byte[HEADER_SIZE];
+        int read = 0;
+        while (read < HEADER_SIZE) {
+            int n = is.read(header, read, HEADER_SIZE - read);
+            if (n == -1) {
+                break;
+            }
+            read += n;
+        }
+        if (read < HEADER_SIZE) {
+            return false;
+        }
+
+        if (!isRiffWebp(header)) {
+            return false;
+        }
+
+        return hasAnimationFlag(header);
+    }
+
+    public static Long getAnimatedWebpDuration(String path) {
+        if (TextUtils.isEmpty(path)) {
+            return null;
+        }
+        File file = new File(path);
+        if (!file.exists() || !file.isFile()) {
+            return null;
+        }
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return getAnimatedWebpDuration(fis);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static long getAnimatedWebpDuration(InputStream is) throws IOException {
+        if (is == null) {
+            return 0;
+        }
+
+        byte[] header = new byte[12];
+        if (readFully(is, header, 0, header.length) < header.length) {
+            return 0;
+        }
+
+        if (!isRiffWebp(header)) {
+            return 0;
+        }
+
+        boolean hasAnimation = false;
+        long duration = 0;
+        byte[] chunkHeader = new byte[8];
+
+        while (true) {
+            int read = readFully(is, chunkHeader, 0, chunkHeader.length);
+            if (read < chunkHeader.length) {
+                break;
+            }
+            String chunkTag = new String(chunkHeader, 0, 4, "ASCII");
+            long chunkSize = readLittleEndian(chunkHeader, 4) & 0xFFFFFFFFL;
+            if ("ANMF".equals(chunkTag) && chunkSize >= 20) {
+                byte[] chunkBody = new byte[20];
+                if (readFully(is, chunkBody, 0, chunkBody.length) < chunkBody.length) {
+                    break;
+                }
+                int frameDelay = (int) readLittleEndian24(chunkBody, 17);
+                if (frameDelay <= 10) {
+                    frameDelay = 100;
+                }
+                duration += frameDelay;
+                hasAnimation = true;
+                long skipBytes = chunkSize - chunkBody.length;
+                if (skipBytes > 0 && !skipFully(is, skipBytes)) {
+                    break;
+                }
+            } else {
+                if (!skipFully(is, chunkSize)) {
+                    break;
+                }
+            }
+            if ((chunkSize & 1) == 1) {
+                if (!skipFully(is, 1)) {
+                    break;
+                }
+            }
+        }
+        return hasAnimation ? duration : 0;
+    }
+
+    private static int readFully(InputStream is, byte[] buffer, int offset, int length) throws IOException {
+        int read = 0;
+        while (read < length) {
+            int n = is.read(buffer, offset + read, length - read);
+            if (n == -1) {
+                break;
+            }
+            read += n;
+        }
+        return read;
+    }
+
+    private static boolean skipFully(InputStream is, long length) throws IOException {
+        while (length > 0) {
+            long skipped = is.skip(length);
+            if (skipped <= 0) {
+                int b = is.read();
+                if (b == -1) {
+                    return false;
+                }
+                skipped = 1;
+            }
+            length -= skipped;
+        }
+        return true;
+    }
+
+    private static long readLittleEndian24(byte[] data, int offset) {
+        return ((data[offset] & 0xFFL))
+                | ((data[offset + 1] & 0xFFL) << 8)
+                | ((data[offset + 2] & 0xFFL) << 16);
+    }
+
+    private static boolean isRiffWebp(byte[] header) {
+        return header[0] == 'R' && header[1] == 'I' && header[2] == 'F' && header[3] == 'F'
+                && header[8] == 'W' && header[9] == 'E' && header[10] == 'B' && header[11] == 'P';
+    }
+
+    private static boolean hasAnimationFlag(byte[] header) {
+        if (header[12] != 'V' || header[13] != 'P' || header[14] != '8' || header[15] != 'X') {
+            return false;
+        }
+        int size = readLittleEndian(header, 16);
+        if (size < VP8X_CHUNK_SIZE) {
+            return false;
+        }
+        return (header[20] & ANIMATION_FLAG) != 0;
+    }
+
+    private static int readLittleEndian(byte[] data, int offset) {
+        return (data[offset] & 0xFF)
+                | ((data[offset + 1] & 0xFF) << 8)
+                | ((data[offset + 2] & 0xFF) << 16)
+                | ((data[offset + 3] & 0xFF) << 24);
+    }
+}

--- a/app/src/test/java/com/hippo/ehviewer/util/GifUtilsTest.java
+++ b/app/src/test/java/com/hippo/ehviewer/util/GifUtilsTest.java
@@ -1,0 +1,74 @@
+package com.hippo.ehviewer.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.junit.Test;
+
+public class GifUtilsTest {
+
+    @Test
+    public void testStaticGifIsNotAnimated() throws IOException {
+        byte[] gif = createGif(false, 1, 0);
+        assertFalse(GifUtils.isAnimatedGif(new ByteArrayInputStream(gif)));
+        assertEquals(0, GifUtils.getGifAnimationDuration(new ByteArrayInputStream(gif)));
+    }
+
+    @Test
+    public void testAnimatedGifIsDetected() throws IOException {
+        byte[] gif = createGif(true, 2, 120);
+        assertTrue(GifUtils.isAnimatedGif(new ByteArrayInputStream(gif)));
+    }
+
+    @Test
+    public void testAnimatedGifDuration() throws IOException {
+        byte[] gif = createGif(true, 2, 120);
+        assertEquals(240, GifUtils.getGifAnimationDuration(new ByteArrayInputStream(gif)));
+    }
+
+    private byte[] createGif(boolean animated, int frameCount, int delay) {
+        int size = 6 + 7 + frameCount * (animated ? 20 : 12) + 1;
+        byte[] data = new byte[size];
+        System.arraycopy("GIF89a".getBytes(), 0, data, 0, 6);
+        data[6] = 1;
+        data[7] = 0;
+        data[8] = 1;
+        data[9] = 0;
+        data[10] = 0;
+        data[11] = 0;
+        data[12] = 0;
+
+        int offset = 13;
+        for (int i = 0; i < frameCount; i++) {
+            if (animated) {
+                data[offset++] = 0x21;
+                data[offset++] = (byte) 0xF9;
+                data[offset++] = 0x04;
+                data[offset++] = 0x00;
+                data[offset++] = (byte) (delay & 0xFF);
+                data[offset++] = (byte) ((delay >> 8) & 0xFF);
+                data[offset++] = 0x00;
+                data[offset++] = 0x00;
+            }
+
+            data[offset++] = 0x2C;
+            data[offset++] = 0x00;
+            data[offset++] = 0x00;
+            data[offset++] = 0x00;
+            data[offset++] = 0x00;
+            data[offset++] = 0x01;
+            data[offset++] = 0x00;
+            data[offset++] = 0x01;
+            data[offset++] = 0x00;
+            data[offset++] = 0x00;
+            data[offset++] = 0x02;
+            data[offset++] = 0x00;
+        }
+
+        data[offset] = 0x3B;
+        return data;
+    }
+}

--- a/app/src/test/java/com/hippo/ehviewer/util/WebpUtilsTest.java
+++ b/app/src/test/java/com/hippo/ehviewer/util/WebpUtilsTest.java
@@ -1,0 +1,85 @@
+package com.hippo.ehviewer.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.junit.Test;
+
+public class WebpUtilsTest {
+
+    @Test
+    public void testStaticWebpIsNotAnimated() throws IOException {
+        byte[] header = createWebpHeader(false);
+        assertFalse(WebpUtils.isAnimatedWebp(new ByteArrayInputStream(header)));
+    }
+
+    @Test
+    public void testAnimatedWebpIsDetected() throws IOException {
+        byte[] header = createWebpHeader(true);
+        assertTrue(WebpUtils.isAnimatedWebp(new ByteArrayInputStream(header)));
+    }
+
+    @Test
+    public void testAnimatedWebpDuration() throws IOException {
+        byte[] webp = createAnimatedWebpFile(300);
+        assertEquals(300L, WebpUtils.getAnimatedWebpDuration(new ByteArrayInputStream(webp)));
+    }
+
+    private byte[] createWebpHeader(boolean animated) {
+        byte[] header = new byte[30];
+        System.arraycopy("RIFF".getBytes(), 0, header, 0, 4);
+        header[4] = 20;
+        header[5] = 0;
+        header[6] = 0;
+        header[7] = 0;
+        System.arraycopy("WEBP".getBytes(), 0, header, 8, 4);
+        System.arraycopy("VP8X".getBytes(), 0, header, 12, 4);
+        header[16] = 10;
+        header[17] = 0;
+        header[18] = 0;
+        header[19] = 0;
+        header[20] = animated ? (byte) 0x02 : (byte) 0x00;
+        return header;
+    }
+
+    private byte[] createAnimatedWebpFile(int delay) {
+        byte[] file = new byte[58];
+        System.arraycopy("RIFF".getBytes(), 0, file, 0, 4);
+        file[4] = 50;
+        file[5] = 0;
+        file[6] = 0;
+        file[7] = 0;
+        System.arraycopy("WEBP".getBytes(), 0, file, 8, 4);
+        System.arraycopy("VP8X".getBytes(), 0, file, 12, 4);
+        file[16] = 10;
+        file[17] = 0;
+        file[18] = 0;
+        file[19] = 0;
+        file[20] = 0x02;
+
+        System.arraycopy("ANMF".getBytes(), 0, file, 30, 4);
+        file[34] = 20;
+        file[35] = 0;
+        file[36] = 0;
+        file[37] = 0;
+        file[38] = 0;
+        file[39] = 0;
+        file[40] = 0;
+        file[41] = 0;
+        file[42] = 0;
+        file[43] = 0;
+        file[44] = 0;
+        file[45] = 0;
+        file[46] = 0;
+        file[47] = 0;
+        file[48] = 0;
+        file[49] = 0;
+        file[55] = (byte) (delay & 0xFF);
+        file[56] = (byte) ((delay >> 8) & 0xFF);
+        file[57] = (byte) ((delay >> 16) & 0xFF);
+        return file;
+    }
+}


### PR DESCRIPTION
## 变更目标
将媒体格式检测能力拆分成独立工具层，便于后续下载链路按需接入并单独测试。

## 变更内容
- 新增 `GifUtils` 与 `WebpUtils`。
- 新增对应单元测试：
  - `GifUtilsTest`
  - `WebpUtilsTest`

## 切片说明
本 PR 只引入工具与测试，不包含下载流程改造，确保评审范围单一。

## 依赖
建议先合并 CI 修复 PR #2545（恢复 gradle wrapper），以保障 Actions 构建正常。

## 风险
低风险：新增文件为主，对现有业务逻辑无侵入。
