### PR TITLE
feat: 数据库导入新增「覆盖导入」模式

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/EhDB.java
+++ b/app/src/main/java/com/hippo/ehviewer/EhDB.java
@@ -973,6 +973,18 @@ public class EhDB {
      * @return error string, null for no error
      */
     public static synchronized String importDB(Context context, File file, Handler handler) {
+        return importDB(context, file, handler, false);
+    }
+
+    /**
+     * @param file      The db file
+     * @param overwrite when {@code true}, imported records replace existing records with the
+     *                  same key instead of being skipped — reproducing an "uninstall + import"
+     *                  for downloads and gallery tags without losing the local image files.
+     *                  When {@code false} the legacy merge behavior is used.
+     * @return error string, null for no error
+     */
+    public static synchronized String importDB(Context context, File file, Handler handler, boolean overwrite) {
         try {
             SQLiteDatabase db = SQLiteDatabase.openDatabase(
                     file.getPath(), null, SQLiteDatabase.NO_LOCALIZED_COLLATORS);
@@ -994,7 +1006,7 @@ public class EhDB {
             manager.addDownloadLabel(downloadLabelList);
             // Downloads
             List<DownloadInfo> downloadInfoList = session.getDownloadsDao().queryBuilder().list();
-            manager.addDownload(downloadInfoList);
+            manager.addDownload(downloadInfoList, overwrite);
 
             sendImportProgress(handler, 50);
             // Download dirname
@@ -1055,7 +1067,14 @@ public class EhDB {
             List<GalleryTags> galleryTagsList = session.getGalleryTagsDao().queryBuilder().list();
             List<GalleryTags> currentGalleryTags = sDaoSession.getGalleryTagsDao().queryBuilder().list();
             for (GalleryTags tags : galleryTagsList) {
-                if (!currentGalleryTags.contains(tags)) {
+                if (overwrite) {
+                    // Replace tags for this gid so edited tag info wins.
+                    GalleryTags exist = queryGalleryTags(tags.gid);
+                    if (exist != null) {
+                        deleteGalleryTags(exist);
+                    }
+                    insertGalleryTags(tags);
+                } else if (!currentGalleryTags.contains(tags)) {
                     insertGalleryTags(tags);
                 }
             }

--- a/app/src/main/java/com/hippo/ehviewer/download/DownloadManager.java
+++ b/app/src/main/java/com/hippo/ehviewer/download/DownloadManager.java
@@ -521,10 +521,28 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
     }
 
     public void addDownload(List<DownloadInfo> downloadInfoList) {
+        addDownload(downloadInfoList, false);
+    }
+
+    /**
+     * Batch add download records (used by database import).
+     *
+     * @param overwrite when {@code true}, an imported record replaces the existing record
+     *                  that has the same gid. The downloaded image files on disk are kept;
+     *                  only the in-memory record and its DB row are refreshed, so the
+     *                  imported title / label / state win. When {@code false} the existing
+     *                  record is kept and the imported one skipped (legacy merge behavior).
+     */
+    public void addDownload(List<DownloadInfo> downloadInfoList, boolean overwrite) {
         for (DownloadInfo info : downloadInfoList) {
             if (containDownloadInfo(info.gid)) {
-                // Contain
-                continue;
+                if (!overwrite) {
+                    // Contain
+                    continue;
+                }
+                // Overwrite: drop the stale in-memory record so the imported one wins.
+                // Files on disk are untouched; the DB row is updated below via putDownloadInfo.
+                removeDownloadFromMemory(info.gid);
             }
 
             // Ensure download state
@@ -565,6 +583,25 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
                 l.onReload();
             }
         });
+    }
+
+    /**
+     * Remove a download record from the in-memory structures only, without deleting the
+     * downloaded files or the DB row. Used by the overwrite import path so the imported
+     * record can be re-added cleanly (its DB row is then refreshed via putDownloadInfo).
+     */
+    private void removeDownloadFromMemory(long gid) {
+        DownloadInfo info = mAllInfoMap.get(gid);
+        if (info == null) {
+            return;
+        }
+        mAllInfoList.remove(info);
+        mAllInfoMap.remove(gid);
+        mWaitList.remove(info);
+        LinkedList<DownloadInfo> list = getInfoListForLabel(info.label);
+        if (list != null) {
+            list.remove(info);
+        }
     }
 
     public void addDownloadLabel(List<DownloadLabel> downloadLabelList) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/fragment/AdvancedFragment.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/fragment/AdvancedFragment.java
@@ -161,18 +161,32 @@ public class AdvancedFragment extends BasePreferenceFragmentCompat
         Arrays.sort(files);
         new AlertDialog.Builder(context).setItems(files, (dialog, which) -> {
             dialog.dismiss();
-            showProgress(context, dir, files, which);
+            chooseImportMode(context, dir, files, which);
         }).show();
         return false;
     }
 
-    private void showProgress(final Context context, File dir, String[] files, int which) {
+    private void chooseImportMode(final Context context, File dir, String[] files, int which) {
+        CharSequence[] modes = new CharSequence[]{
+                context.getString(R.string.import_mode_merge),
+                context.getString(R.string.import_mode_overwrite)
+        };
+        new AlertDialog.Builder(context)
+                .setTitle(R.string.import_mode_title)
+                .setItems(modes, (dialog, mode) -> {
+                    dialog.dismiss();
+                    // mode 0 = merge (legacy), mode 1 = overwrite
+                    showProgress(context, dir, files, which, mode == 1);
+                }).show();
+    }
+
+    private void showProgress(final Context context, File dir, String[] files, int which, boolean overwrite) {
 
         File file = new File(dir, files[which]);
         ProgressHelper.showDialog(context, context.getString(R.string.loading_db_file));
         new Thread(
                 () -> {
-                    String error = EhDB.importDB(context, file, dbSyncHandle);
+                    String error = EhDB.importDB(context, file, dbSyncHandle, overwrite);
                     Message message = new Message();
                     Bundle bundle = new Bundle();
                     bundle.putString("error", error);

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -649,6 +649,9 @@
     <string name="settings_advanced_import_data">导入数据</string>
     <string name="settings_advanced_import_data_summary">从外置存储器导入数据</string>
     <string name="settings_advanced_import_data_successfully">导入数据成功</string>
+    <string name="import_mode_title">导入方式</string>
+    <string name="import_mode_merge">合并（保留现有记录）</string>
+    <string name="import_mode_overwrite">覆盖（以导入数据为准）</string>
     <string name="settings_advanced_wifi_sender">WiFi 数据迁移</string>
     <string name="settings_advanced_wifi_sander_summary">通过WiFi热点迁移数据</string>
     <string name="settings_advanced_wifi_client">WiFi 迁移数据接收</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -737,6 +737,9 @@
     <string name="settings_advanced_import_data">Import data</string>
     <string name="settings_advanced_import_data_summary">Load data which were previously saved</string>
     <string name="settings_advanced_import_data_successfully">Data imported successfully</string>
+    <string name="import_mode_title">Import mode</string>
+    <string name="import_mode_merge">Merge (keep existing records)</string>
+    <string name="import_mode_overwrite">Overwrite (imported data wins)</string>
     <string name="settings_advanced_wifi_sender">WiFi data migration</string>
     <string name="settings_advanced_wifi_sander_summary">Data Migration via Wi-Fi Hotspot</string>
     <string name="settings_advanced_wifi_client">WiFi migration data reception</string>

--- a/docs/import-overwrite-mode.md
+++ b/docs/import-overwrite-mode.md
@@ -1,0 +1,79 @@
+# 数据库导入：新增「覆盖导入」模式
+
+## 背景与问题
+
+EhViewer 的「设置 → 高级 → 导入数据」原本只有**合并**语义：导入一个数据库时，
+对于已存在的记录（按主键判断）一律**跳过**，导致：
+
+- 在电脑上迁移漫画、修改了标题/标签/标签分组等信息后，重新导入数据库，
+  **同 GID 的旧记录纹丝不动**，新信息无法生效；
+- 唯一的变通办法是**卸载 App 再导入**（让数据库回到空表状态再灌入），非常麻烦。
+
+根因在导入逻辑里：
+
+- `DownloadManager.addDownload(List)`：`if (containDownloadInfo(info.gid)) continue;`
+  —— 同 GID 直接跳过。
+- `EhDB.importDB(...)` 中 `GALLERY_TAGS` 也是「不存在才插入」。
+
+## 方案
+
+新增一个**可选的「覆盖导入」模式**，与原「合并导入」并存，由用户在导入时选择：
+
+- **合并（保留现有记录）**：完全等同旧行为，默认、零风险。
+- **覆盖（以导入数据为准）**：同 GID 的下载记录与画廊标签用导入数据**替换**，
+  效果等价于「卸载重装 + 导入」，但**不会删除本地已下载的图片文件**。
+
+## 修改清单
+
+### 1. `app/src/main/java/com/hippo/ehviewer/download/DownloadManager.java`
+
+- 保留原 `addDownload(List<DownloadInfo>)`，改为委托调用新方法 `addDownload(list, false)`。
+- 新增 `addDownload(List<DownloadInfo>, boolean overwrite)`：
+  - `overwrite == false`：同 GID 跳过（旧行为）。
+  - `overwrite == true`：先调用 `removeDownloadFromMemory(gid)` 移除旧的内存记录，
+    再走正常添加流程；下方 `EhDB.putDownloadInfo(info)` 为 insert-or-update，
+    会刷新数据库行。**磁盘上的图片文件不受影响。**
+- 新增私有方法 `removeDownloadFromMemory(long gid)`：仅清理内存结构
+  （`mAllInfoList` / `mAllInfoMap` / `mWaitList` / 对应 label 列表），
+  **不删除文件、不删除数据库行**（由后续 put 覆盖）。
+
+### 2. `app/src/main/java/com/hippo/ehviewer/EhDB.java`
+
+- `importDB(Context, File, Handler)` 改为委托 `importDB(context, file, handler, false)`，
+  保持对旧调用方的兼容。
+- 新增 `importDB(Context, File, Handler, boolean overwrite)`：
+  - 下载记录：`manager.addDownload(downloadInfoList, overwrite)`。
+  - 画廊标签 `GALLERY_TAGS`：`overwrite == true` 时按 GID 查询已有记录、删除后重新插入，
+    使修改过的标签信息生效；`overwrite == false` 时维持「不存在才插入」。
+  - 其余表（dirname 本就是 insert-or-update、history / quicksearch / 收藏 / filter /
+    blacklist）行为不变。
+
+### 3. `app/src/main/java/com/hippo/ehviewer/ui/fragment/AdvancedFragment.java`
+
+- 选择数据库文件后，新增二级对话框 `chooseImportMode(...)` 让用户选择
+  「合并 / 覆盖」。
+- `showProgress(...)` 增加 `boolean overwrite` 参数并透传给 `EhDB.importDB(...)`。
+
+### 4. 字符串资源
+
+- `app/src/main/res/values/strings.xml`（英文）
+- `app/src/main/res/values-zh-rCN/strings.xml`（简体中文）
+
+新增三条：`import_mode_title`、`import_mode_merge`、`import_mode_overwrite`。
+
+## 行为对照
+
+| 数据 | 合并（旧/默认） | 覆盖（新增） |
+|------|----------------|--------------|
+| 下载记录（同 GID 标题/标签/状态/分组） | 跳过，旧值保留 | 用导入值替换 |
+| 下载目录名 DIRNAME | 覆盖（原本即是） | 覆盖 |
+| 画廊标签 GALLERY_TAGS | 不存在才插入 | 按 GID 替换 |
+| 历史 / 快速搜索 / 本地收藏 / 过滤 / 黑名单 | 合并 | 合并（不变） |
+| 本地已下载图片文件 | 不动 | **不动**（仅改数据库记录） |
+
+## 安全性说明
+
+- 「合并」为默认项，旧用户路径零变化。
+- 「覆盖」只触及数据库记录，**绝不删除已下载的漫画图片**，因此即使误选也不会丢图，
+  大不了再导入一次正确的数据库即可恢复记录。
+- 建议覆盖导入前仍按惯例先 `导出数据` 备份一次。


### PR DESCRIPTION
## 背景

「设置 → 高级 → 导入数据」目前只有**合并**语义：同 GID 的下载记录会被直接跳过，导致在外部修改（如迁移漫画后改标题/标签）后重新导入，旧记录无法被更新，只能**卸载重装再导入**。

## 改动

新增一个**可选的「覆盖导入」模式**，与原「合并导入」并存，默认仍为合并（旧行为零变化）：

- `DownloadManager.addDownload`：新增 `addDownload(list, overwrite)` 重载。覆盖模式下先移除旧的内存记录再重新写入（`putDownloadInfo` 为 insert-or-update），**不删除已下载的图片文件**。
- `EhDB.importDB`：新增 `overwrite` 参数（保留原三参重载兼容）。覆盖模式下下载记录与 `GALLERY_TAGS` 按 GID 替换。
- `AdvancedFragment`：选择数据库文件后弹出「合并 / 覆盖」选择对话框。
- 新增中英文字符串资源 `import_mode_*`。
- 新增说明文档 `docs/import-overwrite-mode.md`。

## 行为对照

| 数据 | 合并（默认） | 覆盖（新增） |
|------|------|------|
| 下载记录（同 GID） | 跳过 | 替换 |
| GALLERY_TAGS | 不存在才插入 | 按 GID 替换 |
| 已下载图片文件 | 不动 | **不动** |
| 其它表 | 合并 | 合并（不变） |

## 安全性

- 默认走合并，旧路径无影响。
- 覆盖仅改数据库记录，**绝不删除漫画图片**，误选也不丢图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)