### PR TITLE
fix: Cookie 登录剪贴板导入兼容标准 key=value 格式

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/sign/CookieSignInScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/sign/CookieSignInScene.java
@@ -243,33 +243,67 @@ public class CookieSignInScene extends SolidScene implements EditText.OnEditorAc
             ClipData data = clipboardManager.getPrimaryClip();
             ClipData.Item item = data.getItemAt(0);
             String cookieData = String.valueOf(item.getText());
-            String[] cookieRows = cookieData.split("\n");
-            if (cookieRows.length < 2) {
-                Toast.makeText(getContext(), R.string.no_cookie_in_clipboard, Toast.LENGTH_LONG).show();
-                return;
-            }
+            // Accept both the legacy "key:value" per-line format and the common
+            // "key=value; key=value" cookie header format. Entries may be separated
+            // by newlines and/or semicolons; key and value by ':' or '='.
+            String[] cookieRows = cookieData.split("[\\n;]");
+            boolean found = false;
             for (String cookieRow : cookieRows) {
-                handleCookie(cookieRow);
+                if (handleCookie(cookieRow)) {
+                    found = true;
+                }
+            }
+            if (!found) {
+                Toast.makeText(getContext(), R.string.no_cookie_in_clipboard, Toast.LENGTH_LONG).show();
             }
         }catch (NullPointerException e){
             Toast.makeText(getContext(), R.string.cookie_in_clipboard_incorrect, Toast.LENGTH_LONG).show();
         }
     }
 
-    public void handleCookie(String cookieRow) {
-        String cleanRow = cookieRow.replace(" ", "");
-        String[] cookieData = cleanRow.split(":");
-        if (cookieData.length != 2) {
-            Toast.makeText(getContext(), R.string.no_cookie_in_clipboard, Toast.LENGTH_LONG).show();
-            return;
+    // Returns true if the row contained a recognized cookie that was applied.
+    public boolean handleCookie(String cookieRow) {
+        if (cookieRow == null) {
+            return false;
         }
-        if (cookieData[0].equals(EhCookieStore.KEY_IPD_PASS_HASH) && mIpbPassHash != null) {
-            mIpbPassHash.setText(cookieData[1]);
-        } else if (cookieData[0].equals(EhCookieStore.KEY_IPD_MEMBER_ID) && mIpbMemberId != null) {
-            mIpbMemberId.setText(cookieData[1]);
-        } else if (cookieData[0].equals(EhCookieStore.KEY_IGNEOUS) && mIgneous != null) {
-            mIgneous.setText(cookieData[1]);
+        String cleanRow = cookieRow.trim();
+        if (cleanRow.isEmpty()) {
+            return false;
         }
+        // Key and value may be separated by ':' or '='; use the first one that appears.
+        int sep = separatorIndex(cleanRow);
+        if (sep <= 0) {
+            return false;
+        }
+        String key = cleanRow.substring(0, sep).trim();
+        String value = cleanRow.substring(sep + 1).trim();
+        if (key.isEmpty() || value.isEmpty()) {
+            return false;
+        }
+        if (key.equals(EhCookieStore.KEY_IPD_PASS_HASH) && mIpbPassHash != null) {
+            mIpbPassHash.setText(value);
+            return true;
+        } else if (key.equals(EhCookieStore.KEY_IPD_MEMBER_ID) && mIpbMemberId != null) {
+            mIpbMemberId.setText(value);
+            return true;
+        } else if (key.equals(EhCookieStore.KEY_IGNEOUS) && mIgneous != null) {
+            mIgneous.setText(value);
+            return true;
+        }
+        return false;
+    }
+
+    // Index of the first ':' or '=' in the row, or -1 if neither is present.
+    private static int separatorIndex(String row) {
+        int colon = row.indexOf(':');
+        int equal = row.indexOf('=');
+        if (colon < 0) {
+            return equal;
+        }
+        if (equal < 0) {
+            return colon;
+        }
+        return Math.min(colon, equal);
     }
 
     private static Cookie newCookie(String name, String value, String domain) {


### PR DESCRIPTION
## 问题

Cookie 登录页的「从剪贴板导入」按钮解析过于严格,只接受**每行一个、冒号分隔、且至少两行**的格式:

- 按 `\n` 分割且要求 `length >= 2`(单行直接拒绝);
- 每行只按 `:` 分割,要求正好两段;
- 用 `=`/`;` 的标准 cookie 串(浏览器、Cookie 导出插件、网页控制台 `document.cookie` 的通用格式)完全无法识别。

实际用户最常拿到的就是 `ipb_member_id=...; ipb_pass_hash=...; igneous=...` 这种单行分号格式,导致导入几乎总是失败。

## 改动(`CookieSignInScene.java`)

- 条目分隔同时支持**换行和分号** `split("[\n; ]")`;
- 键值分隔同时支持 **`:` 和 `=`**(取第一个出现的);
- 用 `trim()` 去首尾空格(替代原来删除全部空格),放宽单行限制;
- `handleCookie` 改为返回是否命中,仅在**整体没识别到任何有效 cookie 时提示一次**,不再每行误报 toast;
- 未知键(如 `yay`)安全忽略。

兼容性:原「冒号 + 每行一个」格式继续可用。

## 现在这些都能导入

```
ipb_member_id=xxxxx; ipb_pass_hash=xxxxxxxx; igneous=xxxx
```
```
ipb_member_id:xxx
ipb_pass_hash:xxxxxxxxxx
```

已本地编译通过(assembleDebug),debug 包真机验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)