### PR TITLE
fix: route tag-search syntax through f_search in specify-tag mode

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/data/ListUrlBuilder.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/data/ListUrlBuilder.java
@@ -32,6 +32,7 @@ import com.hippo.ehviewer.client.EhConfig;
 import com.hippo.ehviewer.client.EhUrl;
 import com.hippo.ehviewer.client.EhUtils;
 import com.hippo.ehviewer.dao.QuickSearch;
+import com.hippo.ehviewer.util.TagSearchQueryHelper;
 import com.hippo.ehviewer.widget.AdvanceSearchTable;
 import com.hippo.ehviewer.widget.GalleryInfoContentHelper;
 import com.hippo.network.UrlBuilder;
@@ -623,10 +624,26 @@ public class ListUrlBuilder implements Cloneable, Parcelable {
                 return sb.toString();
             }
             case MODE_TAG: {
+                String keyword = TagSearchQueryHelper.normalizeSpecifiedTagQuery(mKeyword);
+                if (TagSearchQueryHelper.shouldUseTagSearch(keyword)) {
+                    UrlBuilder ub = new UrlBuilder(EhUrl.getHost());
+                    try {
+                        ub.addQuery("f_search", URLEncoder.encode(keyword, "UTF-8"));
+                    } catch (UnsupportedEncodingException e) {
+                        // Empty
+                    }
+                    ub.addQuery("advsearch", "1");
+                    ub.addQuery("f_stags", "on");
+                    if (mPageIndex != 0) {
+                        ub.addQuery("page", mPageIndex);
+                    }
+                    return ub.build();
+                }
+
                 StringBuilder sb = new StringBuilder(EhUrl.getHost());
                 sb.append("tag/");
                 try {
-                    sb.append(URLEncoder.encode(mKeyword, "UTF-8"));
+                    sb.append(URLEncoder.encode(keyword, "UTF-8"));
                 } catch (UnsupportedEncodingException e) {
                     // Empty
                 }

--- a/app/src/main/java/com/hippo/ehviewer/util/TagSearchQueryHelper.java
+++ b/app/src/main/java/com/hippo/ehviewer/util/TagSearchQueryHelper.java
@@ -1,0 +1,42 @@
+package com.hippo.ehviewer.util;
+
+import com.hippo.ehviewer.client.EhTagDatabase;
+
+public final class TagSearchQueryHelper {
+
+    private TagSearchQueryHelper() {
+    }
+
+    public static boolean shouldUseTagSearch(String keyword) {
+        if (keyword == null) {
+            return false;
+        }
+
+        String normalized = keyword.trim();
+        if (normalized.isEmpty()) {
+            return false;
+        }
+
+        if (normalized.indexOf('"') >= 0 ||
+                normalized.indexOf('$') >= 0 ||
+                normalized.indexOf('|') >= 0 ||
+                normalized.indexOf('~') >= 0) {
+            return true;
+        }
+
+        int namespaceIndex = normalized.indexOf(':');
+        if (namespaceIndex <= 0) {
+            return false;
+        }
+
+        String prefix = normalized.substring(0, namespaceIndex + 1);
+        return EhTagDatabase.prefixToNamespace(prefix) != null;
+    }
+
+    public static String normalizeSpecifiedTagQuery(String keyword) {
+        if (keyword == null) {
+            return "";
+        }
+        return keyword.trim();
+    }
+}

--- a/app/src/test/java/com/hippo/ehviewer/util/TagSearchQueryHelperTest.java
+++ b/app/src/test/java/com/hippo/ehviewer/util/TagSearchQueryHelperTest.java
@@ -1,0 +1,23 @@
+package com.hippo.ehviewer.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TagSearchQueryHelperTest {
+
+    @Test
+    public void shouldUseTagSearch_detectsSearchSyntax() {
+        assertEquals(true, TagSearchQueryHelper.shouldUseTagSearch("m:shotacon"));
+        assertEquals(true, TagSearchQueryHelper.shouldUseTagSearch("m:\"shotacon$\""));
+        assertEquals(true, TagSearchQueryHelper.shouldUseTagSearch("female:big breasts|male:sole male"));
+        assertEquals(false, TagSearchQueryHelper.shouldUseTagSearch("male:shotacon"));
+        assertEquals(false, TagSearchQueryHelper.shouldUseTagSearch("female:big breasts"));
+    }
+
+    @Test
+    public void normalizeSpecifiedTagQuery_trimsOnly() {
+        assertEquals("m:\"shotacon$\"",
+                TagSearchQueryHelper.normalizeSpecifiedTagQuery("  m:\"shotacon$\"  "));
+    }
+}


### PR DESCRIPTION
# 背景

在 specify-tag 模式下，查询如 m:"shotacon$" 和 f:"lolicon$" 在 MODE_TAG 路由下会出现结果缺失的问题，但在网页端 search-box 中使用相同语法可以正常返回。

该问题的根本原因在于当前 MODE_TAG 实现会将所有输入统一转换为 /tag/... 路径。该行为对于普通 tag 查询是正确的，但对于包含 namespace 语法或精确匹配标记（如 $）的 search-box 风格查询不兼容，导致查询语义在转换过程中丢失。

因此，MODE_TAG 模式下的处理行为与网页端 search-box 的实际搜索行为不一致，从而造成结果差异与缺失问题。

# 修改文件
- app/src/main/java/com/hippo/ehviewer/client/data/ListUrlBuilder.java
- app/src/main/java/com/hippo/ehviewer/util/TagSearchQueryHelper.java
- app/src/test/java/com/hippo/ehviewer/util/TagSearchQueryHelperTest.java
# 修改内容

在 MODE_TAG 模式下新增对 tag-search 语法的识别逻辑，当检测到 namespace 或 search-box 风格语法时，不再转换为 /tag/... 路径，而是路由至 f_search，并启用 advsearch=1 与 f_stags=on 参数。

普通 tag 查询仍保持原有 /tag/... 路由逻辑不变，以保证兼容性。

# 修改结果

修复了 MODE_TAG 下 namespace 查询（如 m:"shotacon$"、f:"lolicon$"）无法正确命中搜索结果的问题，使其与网页端 search-box 行为保持一致，同时不影响原有 tag path 查询逻辑。

Fixes https://github.com/xiaojieonly/Ehviewer_CN_SXJ/issues/2190
Fixes https://github.com/xiaojieonly/Ehviewer_CN_SXJ/issues/2643
Fixes https://github.com/xiaojieonly/Ehviewer_CN_SXJ/issues/2443 可能