### PR TITLE
feat: add LAN server mode for browsing downloaded items across devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -245,10 +245,23 @@
             android:label="@string/wifi_client"
             android:theme="@style/AppTheme.Toolbar" />
 
+        <activity
+            android:name=".ui.server.ServerLogActivity"
+            android:configChanges="screenSize|uiMode"
+            android:label="@string/server_open_logs_title"
+            android:theme="@style/AppTheme.Toolbar" />
+
         <service
             android:name=".download.DownloadService"
             android:foregroundServiceType="dataSync"
             android:label="@string/download_service_label" />
+
+        <service
+            android:name=".server.service.LanServerService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:label="@string/server_notification_title" />
 
         <provider
             android:name="com.hippo.content.FileProvider"

--- a/app/src/main/assets/server/index.html
+++ b/app/src/main/assets/server/index.html
@@ -1,0 +1,2077 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EhViewer LAN Browser</title>
+  <style>
+    :root {
+      --bg: #f3f5f7;
+      --surface: #ffffff;
+      --text: #132332;
+      --muted: #60758a;
+      --border: #d7e0e8;
+      --accent: #0f7665;
+      --accent-soft: #e1f5f1;
+      --warn: #e97142;
+      --shadow: 0 10px 28px rgba(8, 26, 40, 0.09);
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      color: var(--text);
+      background:
+        radial-gradient(1200px 360px at -5% -15%, #d8eee9 5%, transparent 55%),
+        radial-gradient(900px 320px at 100% -10%, #dce9f9 8%, transparent 55%),
+        var(--bg);
+      font-family: "Segoe UI", "Noto Sans", sans-serif;
+      min-height: 100vh;
+    }
+    .shell {
+      max-width: 1320px;
+      margin: 0 auto;
+      padding: 0 12px 20px;
+    }
+    .panel {
+      position: sticky;
+      top: 0;
+      z-index: 8;
+      background: rgba(243, 245, 247, 0.92);
+      backdrop-filter: blur(9px);
+      border-bottom: 1px solid var(--border);
+      padding: 12px 0;
+    }
+    .toolbar {
+      display: grid;
+      grid-template-columns: minmax(160px, 220px) minmax(180px, 240px) minmax(220px, 1fr) auto auto auto;
+      gap: 8px;
+      align-items: center;
+    }
+    .input, .select, button {
+      border: 1px solid var(--border);
+      background: var(--surface);
+      border-radius: 12px;
+      font-size: 14px;
+      min-height: 40px;
+      padding: 9px 12px;
+      color: var(--text);
+    }
+    .input:focus, .select:focus, button:focus {
+      outline: none;
+      border-color: #4a9f90;
+      box-shadow: 0 0 0 2px rgba(74, 159, 144, 0.15);
+    }
+    button {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .btn-primary {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: #fff;
+    }
+    .btn-soft {
+      border-color: #bdd6dd;
+      background: #edf7fb;
+      color: #21526b;
+    }
+    .modes {
+      display: flex;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      background: var(--surface);
+      min-height: 40px;
+    }
+    .mode {
+      min-height: 38px;
+      border: none;
+      border-radius: 0;
+      min-width: 70px;
+      background: transparent;
+    }
+    .mode.active {
+      background: var(--accent-soft);
+      color: #06564a;
+      font-weight: 700;
+    }
+    .path {
+      display: none; /* hidden: not needed for indexed (non-path-based) browsing */
+    }
+    .status {
+      margin-top: 8px;
+      font-size: 12px;
+      color: var(--muted);
+      min-height: 18px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 10px;
+    }
+    .pager {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .pager button {
+      min-height: 30px;
+      padding: 5px 10px;
+      border-radius: 9px;
+      font-size: 12px;
+    }
+    .pager-text {
+      font-size: 12px;
+      color: var(--muted);
+      min-width: 92px;
+      text-align: center;
+    }
+    .items {
+      margin-top: 14px;
+      display: grid;
+      gap: 12px;
+      grid-template-columns: 1fr;
+    }
+    .items.grid {
+      grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+    }
+    .item {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      box-shadow: var(--shadow);
+      display: grid;
+      grid-template-columns: 84px 1fr;
+      min-height: 92px;
+      overflow: hidden;
+      cursor: pointer;
+      transition: transform .16s ease, box-shadow .16s ease;
+    }
+    .item:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 34px rgba(8, 26, 40, 0.15);
+    }
+    .items.grid .item {
+      grid-template-columns: 1fr;
+    }
+    .thumb-wrap {
+      width: 84px;
+      height: 92px;
+      border-right: 1px solid var(--border);
+      background: linear-gradient(135deg, #edf3f8, #f5f8fb);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #678098;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .items.grid .thumb-wrap {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 2 / 3;
+      border-right: none;
+      border-bottom: 1px solid var(--border);
+    }
+    .items.grid .thumb {
+      object-fit: contain;
+      background: #eef2f5;
+    }
+    .thumb {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .meta {
+      padding: 8px 10px;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      justify-content: center;
+      overflow: hidden;
+    }
+    .title {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.3;
+      font-weight: 700;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+    .items.grid .title {
+      font-size: 14px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .stats {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      font-size: 12px;
+      color: var(--muted);
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .badge {
+      border: 1px solid #cfe1e8;
+      border-radius: 999px;
+      padding: 1px 7px;
+      background: #f4fafc;
+      color: #35556d;
+      font-size: 11px;
+      white-space: nowrap;
+    }
+    .stars {
+      color: #f0a522;
+      font-size: 12px;
+      line-height: 1;
+      white-space: nowrap;
+      font-weight: 600;
+    }
+    .progress-wrap {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-items: center;
+      gap: 6px;
+      min-height: 16px;
+    }
+    .progress-track {
+      height: 4px;
+      border-radius: 999px;
+      background: #ebeff3;
+      overflow: hidden;
+    }
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #1f927f, #3fb6a1);
+    }
+    .progress-text {
+      font-size: 10px;
+      color: var(--muted);
+      min-width: 44px;
+      text-align: right;
+    }
+    .tag-row {
+      display: none;
+    }
+    .tag {
+      font-size: 11px;
+      background: #fff5e9;
+      border: 1px solid #f4d8bd;
+      color: #8d5a29;
+      border-radius: 999px;
+      padding: 1px 7px;
+    }
+    .row {
+      display: none;
+      grid-template-columns: 68px 1fr;
+      gap: 0;
+      align-items: stretch;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      cursor: pointer;
+      min-height: 64px;
+    }
+    .items.list .row {
+      display: grid;
+    }
+    .items.list .item {
+      display: none;
+    }
+    .row .thumb-wrap {
+      width: 68px;
+      height: 100%;
+      border: none;
+      flex-shrink: 0;
+    }
+    .row .thumb {
+      object-fit: cover;
+      height: 100%;
+    }
+    .row-info {
+      padding: 10px 14px;
+      min-width: 0;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-template-rows: auto auto auto;
+      gap: 2px 10px;
+      align-content: center;
+    }
+    .row-title {
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1.3;
+      grid-column: 1 / -1;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .row-sub {
+      font-size: 11px;
+      color: var(--muted);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .row .stars {
+      font-size: 12px;
+      white-space: nowrap;
+      text-align: right;
+    }
+    .row .progress-wrap {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-items: center;
+      gap: 6px;
+      min-height: 14px;
+    }
+    .row .progress-track {
+      height: 3px;
+      border-radius: 999px;
+      background: #ebeff3;
+      overflow: hidden;
+    }
+    .row .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #1f927f, #3fb6a1);
+    }
+    .row .progress-text {
+      font-size: 10px;
+      color: var(--muted);
+      min-width: 40px;
+      text-align: right;
+    }
+    .cell {
+      font-size: 12px;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    .empty {
+      margin-top: 10px;
+      border: 1px dashed #b6c9d8;
+      border-radius: 14px;
+      padding: 24px;
+      text-align: center;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.76);
+    }
+    .empty b {
+      color: #28445c;
+    }
+    /* ── Reader Overlay ── */
+    .reader {
+      position: fixed;
+      inset: 0;
+      z-index: 40;
+      display: none;
+      background: #0a121a;
+      overflow: hidden;
+      overscroll-behavior: contain;
+    }
+    .reader.open {
+      display: grid;
+      grid-template-rows: 1fr;
+      grid-template-columns: 1fr;
+    }
+
+    /* ── Info Overlay Bar ── */
+    .reader-info {
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 14px;
+      font-size: 12px;
+      color: #fff;
+      background: linear-gradient(to bottom, rgba(0,0,0,0.55), transparent);
+      pointer-events: none;
+      user-select: none;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.7);
+    }
+    .reader-info > * {
+      pointer-events: auto;
+    }
+    .reader-info .info-left,
+    .reader-info .info-center,
+    .reader-info .info-right {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    /* ── Close Button ── */
+    .reader-close {
+      position: absolute;
+      top: 8px; right: 14px;
+      z-index: 60;
+      width: 36px; height: 36px;
+      min-width: 36px; min-height: 36px;
+      border: none;
+      padding: 0;
+      background: rgba(0,0,0,0.35);
+      color: #fff;
+      font-size: 22px;
+      font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+      font-weight: 300;
+      border-radius: 50%;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      text-align: center;
+      transition: background 0.2s;
+    }
+    .reader-close:hover {
+      background: rgba(0,0,0,0.6);
+    }
+
+    /* ── Image Stage ── */
+    .reader-stage {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      touch-action: none;
+    }
+
+    /* ── Dual-image Slide Container ── */
+    .reader-slide-wrap {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .reader-slide-img {
+      position: absolute;
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      border-radius: 4px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.5);
+      transition: transform 200ms ease-out;
+      will-change: transform;
+    }
+    .reader-slide-img.fit-width  { object-fit: contain; width: 100%; height: auto; max-height: none; }
+    .reader-slide-img.fit-height { object-fit: contain; width: auto; height: 100%; max-width: none; }
+    .reader-slide-img.fit-fixed  { object-fit: none; }
+
+    .reader-empty {
+      color: #d3dfeb;
+      text-align: center;
+      font-size: 14px;
+    }
+
+    /* ── Tap Zones (3×2 grid) ── */
+    .reader-zone {
+      position: absolute;
+      z-index: 45;
+      cursor: pointer;
+    }
+    .reader-zone.zone-left   { left: 0;    top: 0; width: 33.333%; height: 100%; }
+    .reader-zone.zone-right  { right: 0;   top: 0; width: 33.333%; height: 100%; }
+    .reader-zone.zone-menu   { left: 33.333%; top: 0;  width: 33.333%; height: 50%; }
+    .reader-zone.zone-slider { left: 33.333%; top: 50%; width: 33.333%; height: 50%; }
+
+    /* ── Seek Bar Panel ── */
+    .reader-seek-panel {
+      position: absolute;
+      bottom: 0; left: 0; right: 0;
+      z-index: 55;
+      background: rgba(0,0,0,0.7);
+      padding: 12px 16px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      transform: translateY(100%);
+      transition: transform 200ms ease-out;
+    }
+    .reader-seek-panel.visible {
+      transform: translateY(0);
+    }
+    .reader-seek-panel input[type="range"] {
+      flex: 1;
+      accent-color: #4a9f90;
+    }
+    .reader-seek-panel .seek-page {
+      color: #fff;
+      font-size: 13px;
+      min-width: 60px;
+      text-align: center;
+    }
+    .reader-seek-panel .seek-auto-btn {
+      border: 1px solid rgba(255,255,255,0.3);
+      background: rgba(255,255,255,0.1);
+      color: #fff;
+      border-radius: 8px;
+      padding: 5px 10px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    .reader-seek-panel .seek-auto-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    /* ── Settings Dialog ── */
+    .reader-dialog-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 70;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .reader-dialog {
+      background: #1a2633;
+      border: 1px solid #3f5367;
+      border-radius: 14px;
+      padding: 20px 24px;
+      min-width: 280px;
+      max-width: 360px;
+      width: 90%;
+      color: #e0e8f0;
+      font-size: 14px;
+      box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+    }
+    .reader-dialog h3 {
+      margin: 0 0 14px 0;
+      font-size: 16px;
+      color: #fff;
+    }
+    .reader-dialog .setting-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .reader-dialog .setting-row:last-child {
+      border-bottom: none;
+    }
+    .reader-dialog label {
+      font-size: 13px;
+    }
+    .reader-dialog select,
+    .reader-dialog button {
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.15);
+      color: #e0e8f0;
+      border-radius: 8px;
+      padding: 5px 10px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .reader-dialog .toggle {
+      width: 44px; height: 24px;
+      border-radius: 12px;
+      background: rgba(255,255,255,0.15);
+      position: relative;
+      cursor: pointer;
+      border: none;
+      transition: background 0.2s;
+    }
+    .reader-dialog .toggle.on {
+      background: var(--accent);
+    }
+    .reader-dialog .toggle::after {
+      content: '';
+      position: absolute;
+      top: 2px; left: 2px;
+      width: 20px; height: 20px;
+      border-radius: 50%;
+      background: #fff;
+      transition: transform 0.2s;
+    }
+    .reader-dialog .toggle.on::after {
+      transform: translateX(20px);
+    }
+    .reader-dialog .dialog-actions {
+      margin-top: 16px;
+      display: flex;
+      gap: 8px;
+    }
+    .reader-dialog .dialog-actions button {
+      flex: 1;
+      padding: 8px;
+    }
+    .btn-accent {
+      background: var(--accent) !important;
+      border-color: var(--accent) !important;
+      color: #fff !important;
+      font-weight: 600;
+    }
+
+    /* ── Shortcuts Reference ── */
+    .shortcuts-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 80;
+      background: rgba(0,0,0,0.6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .shortcuts-table {
+      background: #1a2633;
+      border: 1px solid #3f5367;
+      border-radius: 14px;
+      padding: 20px 24px;
+      color: #e0e8f0;
+      max-width: 420px;
+      width: 90%;
+      font-size: 13px;
+      box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+    }
+    .shortcuts-table h3 {
+      margin: 0 0 12px 0;
+      color: #fff;
+      font-size: 16px;
+    }
+    .shortcuts-table table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .shortcuts-table td {
+      padding: 4px 0;
+    }
+    .shortcuts-table td:first-child {
+      font-family: monospace;
+      color: #8ec8b8;
+      width: 160px;
+    }
+    .shortcuts-table td:last-child {
+      color: #a0b4c8;
+    }
+    @media (min-width: 1200px) {
+      .items.grid {
+        grid-template-columns: repeat(auto-fill, minmax(155px, 1fr));
+      }
+    }
+    @media (max-width: 1000px) {
+      .toolbar {
+        grid-template-columns: repeat(2, minmax(140px, 1fr));
+      }
+      .row {
+        grid-template-columns: 56px 1fr;
+      }
+      .row .thumb-wrap {
+        width: 56px;
+      }
+      .row-info {
+        padding: 8px 10px;
+      }
+    }
+
+    /* ── Dark Mode ── */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f1419;
+        --surface: #1a2530;
+        --text: #e0e8f0;
+        --muted: #889aad;
+        --border: #2a3a4a;
+        --accent: #3fb6a1;
+        --accent-soft: #142820;
+        --shadow: 0 10px 28px rgba(0,0,0,0.35);
+      }
+      body {
+        background:
+          radial-gradient(1200px 360px at -5% -15%, #1a2a25 5%, transparent 55%),
+          radial-gradient(900px 320px at 100% -10%, #1a2430 8%, transparent 55%),
+          var(--bg);
+      }
+      .panel {
+        background: rgba(15,20,25,0.92);
+      }
+      .badge {
+        border-color: #3a5060;
+        background: #1a2a35;
+        color: #90b8c8;
+      }
+      .tag {
+        background: #2a1f15;
+        border-color: #5a4030;
+        color: #c89660;
+      }
+      .btn-soft {
+        border-color: #3a5060;
+        background: #1a2835;
+        color: #90b8c8;
+      }
+      .thumb-wrap {
+        background: linear-gradient(135deg, #1a2530, #1f2a35);
+        color: #607080;
+      }
+      .progress-track {
+        background: #2a3540;
+      }
+      .row .progress-track {
+        background: #2a3540;
+      }
+      .items.grid .thumb {
+        background: #1a2530;
+      }
+      .empty {
+        background: rgba(26,37,48,0.76);
+        border-color: #3a5060;
+      }
+      .empty b {
+        color: #b0c8d8;
+      }
+      .reader-dialog {
+        background: #141e28;
+        border-color: #2a3a4a;
+      }
+      .shortcuts-table {
+        background: #141e28;
+        border-color: #2a3a4a;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="panel">
+      <div class="toolbar">
+        <select id="label" class="select">
+          <option value="">All labels</option>
+        </select>
+        <input id="tags" class="input" placeholder="Tags: manga,doujin" />
+        <input id="search" class="input" placeholder="Search title or tags" />
+        <button id="applyBtn" class="btn-primary">Apply</button>
+        <button id="clearBtn" class="btn-soft">Clear</button>
+        <div class="modes">
+          <button id="gridBtn" class="mode">Grid</button>
+          <button id="listBtn" class="mode">List</button>
+        </div>
+      </div>
+      <div id="path" class="path">/</div>
+      <div id="status" class="status">
+        <span id="statusText"></span>
+        <span class="pager">
+          <button id="prevPageBtn" class="btn-soft">Prev</button>
+          <span id="pagerText" class="pager-text">Page 1/1</span>
+          <button id="nextPageBtn" class="btn-soft">Next</button>
+        </span>
+      </div>
+    </div>
+
+    <div id="items" class="items grid"></div>
+    <div id="empty" class="empty" style="display:none"></div>
+  </div>
+
+  <div id="reader" class="reader" aria-hidden="true">
+    <div id="readerInfo" class="reader-info">
+      <div class="info-left" id="infoClock">--:--</div>
+      <div class="info-center" id="infoProgress">0 / 0</div>
+      <div class="info-right" id="infoBattery"></div>
+    </div>
+    <button id="readerCloseBtn" class="reader-close" title="Close reader">×</button>
+    <div id="readerStage" class="reader-stage">
+      <div class="reader-slide-wrap" id="readerSlideWrap"></div>
+      <div class="reader-zone zone-left" id="zoneLeft"></div>
+      <div class="reader-zone zone-menu" id="zoneMenu"></div>
+      <div class="reader-zone zone-slider" id="zoneSlider"></div>
+      <div class="reader-zone zone-right" id="zoneRight"></div>
+    </div>
+    <div id="readerSeekPanel" class="reader-seek-panel">
+      <span class="seek-page" id="seekPageText">0 / 0</span>
+      <input type="range" id="seekRange" min="0" max="0" value="0" />
+      <button class="seek-auto-btn" id="seekAutoBtn" title="Auto-transfer">▶</button>
+    </div>
+  </div>
+
+  <script>
+    const itemsEl = document.getElementById('items');
+    const emptyEl = document.getElementById('empty');
+    const statusTextEl = document.getElementById('statusText');
+    const pagerTextEl = document.getElementById('pagerText');
+    const labelEl = document.getElementById('label');
+    const tagsEl = document.getElementById('tags');
+    const searchEl = document.getElementById('search');
+    const applyBtn = document.getElementById('applyBtn');
+    const clearBtn = document.getElementById('clearBtn');
+    const gridBtn = document.getElementById('gridBtn');
+    const listBtn = document.getElementById('listBtn');
+    const prevPageBtn = document.getElementById('prevPageBtn');
+    const nextPageBtn = document.getElementById('nextPageBtn');
+    const readerEl = document.getElementById('reader');
+    const readerStageEl = document.getElementById('readerStage');
+    const readerCloseBtn = document.getElementById('readerCloseBtn');
+    const readerSlideWrap = document.getElementById('readerSlideWrap');
+    const readerInfoEl = document.getElementById('readerInfo');
+    const infoClockEl = document.getElementById('infoClock');
+    const infoProgressEl = document.getElementById('infoProgress');
+    const infoBatteryEl = document.getElementById('infoBattery');
+    const zoneLeftEl = document.getElementById('zoneLeft');
+    const zoneRightEl = document.getElementById('zoneRight');
+    const zoneMenuEl = document.getElementById('zoneMenu');
+    const zoneSliderEl = document.getElementById('zoneSlider');
+    const seekPanelEl = document.getElementById('readerSeekPanel');
+    const seekRangeEl = document.getElementById('seekRange');
+    const seekPageTextEl = document.getElementById('seekPageText');
+    const seekAutoBtn = document.getElementById('seekAutoBtn');
+
+    // ── Global state ──
+    const state = {
+      path: '',
+      mode: localStorage.getItem('lan_mode') || 'grid',
+      filters: { label: '', tags: '', search: '' },
+      rows: [],
+      loading: false,
+      pendingInputTimer: 0,
+      page: 1,
+      limit: 120,
+      totalPages: 1,
+      totalItems: 0,
+      reader: {
+        gid: 0,
+        title: '',
+        pages: [],           // array of { url, name } preloaded Image elements stored as .img
+        index: 0,
+        // settings (persisted)
+        readingDirection: 'rtl',    // 'rtl' or 'ltr'
+        swapTap: false,
+        scaleMode: 'fit',           // 'fit' | 'fitWidth' | 'fitHeight' | 'fixed'
+        fullscreen: false,
+        autoTransfer: false,
+        autoTransferInterval: 3,    // seconds
+        // runtime
+        currentImg: null,   // reference to the currently displayed <img>
+        nextImg: null,      // reference to the next <img> for slide animation
+        controlsVisible: false,
+        zoom: 1,            // current zoom scale (1 = fit)
+        panX: 0,            // current pan offset X
+        panY: 0,            // current pan offset Y
+        autoTransferTimer: null,
+        clockTimer: null,
+        seekHideTimer: null,
+        controlsHideTimer: null,
+        isDragging: false,
+        dragStartX: 0,
+        dragStartY: 0,
+        dragDeltaX: 0,
+        // multi-pointer pinch state
+        pinchActive: false,
+        pinchStartDist: 0,
+        pinchStartScale: 1,
+        pinchMidX: 0,
+        pinchMidY: 0,
+      },
+    };
+
+    // ── Reader settings persistence ──
+    const READER_SETTINGS_KEY = 'reader_settings';
+
+    function loadReaderSettings() {
+      try {
+        const raw = localStorage.getItem(READER_SETTINGS_KEY);
+        if (raw) {
+          const s = JSON.parse(raw);
+          state.reader.readingDirection = s.readingDirection || 'rtl';
+          state.reader.swapTap = !!s.swapTap;
+          state.reader.scaleMode = s.scaleMode || 'fit';
+          state.reader.fullscreen = !!s.fullscreen;
+          state.reader.autoTransfer = !!s.autoTransfer;
+          state.reader.autoTransferInterval = Number(s.autoTransferInterval) || 3;
+        }
+      } catch (_) { /* ignore corrupt settings */ }
+    }
+
+    function saveReaderSettings() {
+      localStorage.setItem(READER_SETTINGS_KEY, JSON.stringify({
+        readingDirection: state.reader.readingDirection,
+        swapTap: state.reader.swapTap,
+        scaleMode: state.reader.scaleMode,
+        fullscreen: state.reader.fullscreen,
+        autoTransfer: state.reader.autoTransfer,
+        autoTransferInterval: state.reader.autoTransferInterval,
+      }));
+    }
+
+    function loadReadingPosition(gid) {
+      try {
+        const raw = localStorage.getItem('reader_progress');
+        if (raw) {
+          const map = JSON.parse(raw);
+          return (map && typeof map[String(gid)] === 'number') ? map[String(gid)] : -1;
+        }
+      } catch (_) { /* ignore */ }
+      return -1;
+    }
+
+    function saveReadingPosition(gid, index) {
+      try {
+        const raw = localStorage.getItem('reader_progress');
+        const map = raw ? JSON.parse(raw) : {};
+        map[String(gid)] = index;
+        localStorage.setItem('reader_progress', JSON.stringify(map));
+      } catch (_) { /* ignore */ }
+    }
+
+    loadReaderSettings();
+
+    function parseInitialUrlState() {
+      const params = new URLSearchParams(location.search);
+      state.path = params.get('path') || '';
+      state.filters.label = params.get('label') || (params.has('label') ? '' : 'Default');
+      state.filters.tags = params.get('tags') || '';
+      state.filters.search = params.get('search') || '';
+      const page = Number(params.get('page') || '1');
+      state.page = Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1;
+      const mode = params.get('mode');
+      if (mode === 'grid' || mode === 'list') {
+        state.mode = mode;
+      }
+    }
+
+    function updateUrlState() {
+      const params = new URLSearchParams();
+      if (state.path) params.set('path', state.path);
+      if (state.filters.label) params.set('label', state.filters.label);
+      if (state.filters.tags) params.set('tags', state.filters.tags);
+      if (state.filters.search) params.set('search', state.filters.search);
+      params.set('page', String(state.page));
+      params.set('mode', state.mode);
+      history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
+    }
+
+    function setMode(mode) {
+      state.mode = mode === 'list' ? 'list' : 'grid';
+      localStorage.setItem('lan_mode', state.mode);
+      itemsEl.className = `items ${state.mode}`;
+      gridBtn.classList.toggle('active', state.mode === 'grid');
+      listBtn.classList.toggle('active', state.mode === 'list');
+      updateUrlState();
+      render();
+    }
+
+    function parseTagsInput(value) {
+      if (!value) return [];
+      return value.split(',').map(x => x.trim()).filter(Boolean);
+    }
+
+    function syncInputsFromState() {
+      labelEl.value = state.filters.label;
+      tagsEl.value = state.filters.tags;
+      searchEl.value = state.filters.search;
+    }
+
+    function syncStateFromInputs() {
+      state.filters.label = labelEl.value.trim();
+      state.filters.tags = tagsEl.value.trim();
+      state.filters.search = searchEl.value.trim();
+    }
+
+    function resetToFirstPage() {
+      state.page = 1;
+    }
+
+    function fmtSize(size) {
+      if (!size || size < 1) return '-';
+      const units = ['B', 'KB', 'MB', 'GB'];
+      let value = size;
+      let unit = 0;
+      while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+      }
+      return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+    }
+
+    function fmtTime(ts) {
+      if (!ts || ts < 1) return '-';
+      return new Date(ts).toLocaleString();
+    }
+
+    function escapeHtml(text) {
+      const value = text == null ? '' : String(text);
+      return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+    }
+
+    function stars(rating) {
+      if (rating == null || Number.isNaN(Number(rating))) {
+        return '<span class="stars">-</span>';
+      }
+      const v = Math.round(Math.max(0, Math.min(5, Number(rating))) * 2) / 2;
+      return `<span class="stars" title="${v.toFixed(1)}">★ ${v.toFixed(1)}/5</span>`;
+    }
+
+    function progressMarkup(progress, pageCount) {
+      const current = Number.isFinite(Number(progress?.current)) ? Math.max(0, Number(progress.current)) : 0;
+      const total = Number.isFinite(Number(progress?.total)) ? Math.max(1, Number(progress.total)) : Number(pageCount) || 0;
+      if (total <= 0) return '<span class="cell">-</span>';
+      const pct = Math.round((current / total) * 100);
+      return `
+        <div class="progress-wrap">
+          <div class="progress-track"><div class="progress-fill" style="width:${Math.min(100, Math.max(0, pct))}%"></div></div>
+          <div class="progress-text">${current}/${total}</div>
+        </div>
+      `;
+    }
+
+    function itemThumb(item) {
+      const title = escapeHtml(item.title || item.name || 'item');
+      if (item.thumbnailUrl && typeof item.thumbnailUrl === 'string') {
+        return `<img class="thumb" src="${escapeHtml(item.thumbnailUrl)}" alt="${title}" loading="lazy" />`;
+      }
+      if (item.image && item.url) {
+        return `<img class="thumb" src="${escapeHtml(item.url)}" alt="${title}" loading="lazy" />`;
+      }
+      return `<span>${item.directory ? 'DIR' : 'FILE'}</span>`;
+    }
+
+    function itemMeta(item) {
+      const tags = Array.isArray(item.tags) ? item.tags.slice(0, 4) : [];
+      const labels = Array.isArray(item.labels) ? item.labels : [];
+      const pages = item.pageCount ? `${item.pageCount}P` : '-';
+      return { tags, labels, pages, safeTitle: escapeHtml(item.title || item.name || 'Untitled') };
+    }
+
+    function cardMarkup(item) {
+      const { safeTitle } = itemMeta(item);
+      const uploader = escapeHtml(item.uploader || '-');
+      return `
+        <article class="item" data-path="${escapeHtml(item.path || '')}" data-dir="${item.directory ? '1' : '0'}">
+          <div class="thumb-wrap">${itemThumb(item)}</div>
+          <div class="meta">
+            <h3 class="title" title="${safeTitle}">${safeTitle}</h3>
+            <div class="stats">
+              ${stars(item.rating)}
+              ${uploader !== '-' ? `<span class="badge">${escapeHtml(uploader)}</span>` : ''}
+            </div>
+            ${progressMarkup(item.readProgress, item.pageCount)}
+          </div>
+        </article>
+      `;
+    }
+
+    function rowMarkup(item) {
+      const { safeTitle } = itemMeta(item);
+      const uploader = escapeHtml(item.uploader || '-');
+      const sizeStr = item.directory ? 'Folder' : fmtSize(item.size);
+      return `
+        <article class="row" data-path="${escapeHtml(item.path || '')}" data-dir="${item.directory ? '1' : '0'}">
+          <div class="thumb-wrap">${itemThumb(item)}</div>
+          <div class="row-info">
+            <div class="row-title">${safeTitle}</div>
+            <div class="row-sub">${uploader !== '-' ? escapeHtml(uploader) : sizeStr}</div>
+            <div>${stars(item.rating)}</div>
+            ${progressMarkup(item.readProgress, item.pageCount)}
+          </div>
+        </article>
+      `;
+    }
+
+    function updateLabelOptions(availableLabels) {
+      // Only rebuild the dropdown when the available labels actually change,
+      // not on every filter change. This ensures users can switch labels
+      // without being forced back to "All labels" first.
+      const labels = Array.isArray(availableLabels) ? availableLabels : [];
+      if (labels.length === 0) return;
+      // Build full option list: "All labels" (no filter) + all available labels
+      const fullOptions = ['', ...labels];
+      const currentValue = labelEl.value;
+      const isRebuildNeeded = labelEl.options.length !== fullOptions.length
+        || fullOptions.some((l, i) => labelEl.options[i]?.value !== l);
+      if (!isRebuildNeeded) {
+        // Just update the selected value without rebuilding
+        const selected = fullOptions.includes(state.filters.label) ? state.filters.label : '';
+        labelEl.value = selected;
+        return;
+      }
+      labelEl.innerHTML = fullOptions.map(l => {
+        if (l === '') return '<option value="">All labels</option>';
+        return `<option value="${escapeHtml(l)}">${escapeHtml(l)}</option>`;
+      }).join('');
+      const selected = fullOptions.includes(state.filters.label) ? state.filters.label : '';
+      labelEl.value = selected;
+      if (!labelEl.value) state.filters.label = '';
+    }
+
+    function render() {
+      const rows = state.rows || [];
+      const hasFilter = Boolean(state.filters.label || state.filters.tags || state.filters.search);
+      const filterSummary = [
+        state.filters.label ? `label=${state.filters.label}` : '',
+        state.filters.tags ? `tags=${state.filters.tags}` : '',
+        state.filters.search ? `search=${state.filters.search}` : '',
+      ].filter(Boolean).join(' | ');
+      statusTextEl.textContent = state.loading
+        ? 'Loading...'
+        : `${rows.length} shown / ${state.totalItems} total${filterSummary ? ` · ${filterSummary}` : ''}`;
+      pagerTextEl.textContent = `Page ${state.page}/${Math.max(1, state.totalPages)}`;
+      prevPageBtn.disabled = state.loading || state.page <= 1;
+      nextPageBtn.disabled = state.loading || state.page >= state.totalPages;
+
+      if (!rows.length) {
+        itemsEl.innerHTML = '';
+        emptyEl.style.display = 'block';
+        emptyEl.innerHTML = hasFilter
+          ? '<b>No items match your filters.</b><br/>Try clearing filters or adjusting keywords.'
+          : '<b>This folder is empty.</b>';
+        return;
+      }
+
+      emptyEl.style.display = 'none';
+      const isGrid = state.mode === 'grid';
+      itemsEl.innerHTML = rows.map(item => isGrid ? cardMarkup(item) : rowMarkup(item)).join('');
+
+      [...itemsEl.querySelectorAll('[data-path]')].forEach(el => {
+        el.addEventListener('click', () => {
+          const path = el.getAttribute('data-path') || '';
+          const isDir = el.getAttribute('data-dir') === '1';
+          if (isDir) {
+            load(path);
+            return;
+          }
+          const target = rows.find(x => (x.path || '') === path);
+          if (target) {
+            openReader(target);
+          }
+        });
+      });
+    }
+
+    function isReaderOpen() {
+      return readerEl.classList.contains('open');
+    }
+
+    function isZoomed() {
+      return Math.abs(state.reader.zoom - 1) > 0.001;
+    }
+
+    // ── Scale mode CSS ──
+    function applyScaleMode(img) {
+      if (!img) return;
+      img.classList.remove('fit-width', 'fit-height', 'fit-fixed');
+      const sm = state.reader.scaleMode;
+      if (sm === 'fitWidth') img.classList.add('fit-width');
+      else if (sm === 'fitHeight') img.classList.add('fit-height');
+      else if (sm === 'fixed') img.classList.add('fit-fixed');
+    }
+
+    function applyZoomAndPan(img) {
+      if (!img) return;
+      img.style.transform = `scale(${state.reader.zoom}) translate(${state.reader.panX}px, ${state.reader.panY}px)`;
+    }
+
+    // ── Page navigation ──
+    function pageCount() { return state.reader.pages.length; }
+    function currentIdx() { return Math.max(0, Math.min(pageCount() - 1, state.reader.index)); }
+
+    function navigateToPage(idx, direction) {
+      const pages = state.reader.pages;
+      if (!pages.length) return;
+      _removeAdjacent();
+      const oldIdx = currentIdx();
+      const newIdx = Math.max(0, Math.min(pages.length - 1, idx));
+      if (newIdx === oldIdx) { updateReaderUI(); return; }
+      // Reset zoom on any page change
+      state.reader.zoom = 1;
+      state.reader.panX = 0;
+      state.reader.panY = 0;
+      state.reader.index = newIdx;
+      const delta = Math.abs(newIdx - oldIdx);
+      if (delta > 1 || !direction) {
+        // instant jump (seek bar or large jump)
+        showPageInstant(newIdx);
+      } else {
+        // slide animation
+        showPageSlide(newIdx, direction);
+      }
+      updateReaderUI();
+      updateReadingProgress();
+    }
+
+    function prevPage() {
+      navigateToPage(currentIdx() - 1, -1);
+    }
+
+    function nextPage() {
+      navigateToPage(currentIdx() + 1, 1);
+    }
+
+    function getEffectivePrev() {
+      return state.reader.swapTap ? 1 : -1;
+    }
+    function getEffectiveNext() {
+      return state.reader.swapTap ? -1 : 1;
+    }
+
+    // ── Slide animation ──
+    function showPageInstant(idx) {
+      const pages = state.reader.pages;
+      const img = pages[idx].img;
+      // Reset zoom on instant jumps too
+      state.reader.zoom = 1;
+      state.reader.panX = 0;
+      state.reader.panY = 0;
+      readerSlideWrap.innerHTML = '';
+      img.style.transform = '';
+      img.style.transition = 'none';
+      img.style.zIndex = '';
+      applyScaleMode(img);
+      readerSlideWrap.appendChild(img);
+      state.reader.currentImg = img;
+      state.reader.nextImg = null;
+    }
+
+    function showPageSlide(newIdx, direction) {
+      const pages = state.reader.pages;
+      const newImg = pages[newIdx].img;
+      const oldImg = state.reader.currentImg;
+
+      // Clean up any pending transition
+      if (state.reader.nextImg && state.reader.nextImg !== newImg) {
+        state.reader.nextImg.style.transition = 'none';
+        state.reader.nextImg.style.transform = '';
+        if (state.reader.nextImg.parentNode) state.reader.nextImg.remove();
+      }
+
+      applyScaleMode(newImg);
+      // Position new image off-screen, respecting reading direction
+      // In RTL: forward → new page comes from LEFT; in LTR: forward → new page comes from RIGHT
+      const isLTR = state.reader.readingDirection === 'ltr';
+      const slideDir = direction * (isLTR ? 1 : -1);
+      newImg.style.transition = 'none';
+      newImg.style.transform = `translateX(${slideDir * 100}%)`;
+      newImg.style.zIndex = '1';  // incoming on top
+      if (!newImg.parentNode) readerSlideWrap.appendChild(newImg);
+
+      // Force reflow
+      newImg.offsetHeight;
+
+      // Animate only the incoming image; remove outgoing instantly
+      if (oldImg) {
+        oldImg.style.transition = 'none';
+        oldImg.style.transform = '';
+        if (oldImg.parentNode) oldImg.remove();
+      }
+      newImg.style.transition = 'transform 200ms ease-out';
+      newImg.style.transform = 'translateX(0)';
+
+      state.reader.nextImg = newImg;
+
+      // On transition end, clean up
+      const onEnd = () => {
+        newImg.removeEventListener('transitionend', onEnd);
+        if (oldImg && oldImg.parentNode) oldImg.remove();
+        state.reader.currentImg = newImg;
+        state.reader.nextImg = null;
+        newImg.style.transition = '';
+        newImg.style.transform = '';
+        // Reset zoom
+        state.reader.zoom = 1;
+        state.reader.panX = 0;
+        state.reader.panY = 0;
+      };
+      newImg.addEventListener('transitionend', onEnd);
+    }
+
+    // ── Preload + open/close ──
+    async function openReader(item) {
+      const gid = Number(item.path || '0');
+      if (!Number.isFinite(gid) || gid <= 0) return;
+
+      readerEl.classList.add('open');
+      readerEl.setAttribute('aria-hidden', 'false');
+      readerSlideWrap.innerHTML = '<div class="reader-empty">Loading reader...</div>';
+      state.reader.gid = gid;
+      state.reader.title = item.title || item.name || `Item ${gid}`;
+      state.reader.pages = [];
+      state.reader.index = 0;
+      state.reader.zoom = 1;
+      state.reader.panX = 0;
+      state.reader.panY = 0;
+
+      try {
+        const res = await fetch(`/api/reader?gid=${encodeURIComponent(String(gid))}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const pageList = Array.isArray(data.pages) ? data.pages : [];
+        const savedPos = loadReadingPosition(gid);
+        const startIdxRaw = savedPos >= 0 ? savedPos : Number(data.startIndex || 0);
+        const startIdx = Number.isFinite(startIdxRaw) ? Math.max(0, Math.floor(startIdxRaw)) : 0;
+
+        // Preload all images
+        const pages = pageList.map(p => {
+          const img = new Image();
+          img.src = p.url || '';
+          img.alt = p.name || '';
+          img.className = 'reader-slide-img';
+          img.draggable = false;
+          return { url: p.url, name: p.name, img };
+        });
+
+        state.reader.pages = pages;
+        state.reader.index = Math.min(startIdx, pages.length - 1);
+        state.reader.title = data.title || state.reader.title;
+
+        showPageInstant(state.reader.index);
+        updateReaderUI();
+        startClock();
+        updateBattery();
+      } catch (error) {
+        readerSlideWrap.innerHTML = `<div class="reader-empty">Failed to open reader: ${escapeHtml(error.message || String(error))}</div>`;
+      }
+    }
+
+    function closeReader() {
+      stopAutoTransfer();
+      stopClock();
+      clearTimeout(state.reader.seekHideTimer);
+      clearTimeout(state.reader.controlsHideTimer);
+      clearTimeout(state.reader._debounceTimer);
+      clearTimeout(state.reader._autoResumeTimer);
+      state.reader._debounceTimer = null;
+      state.reader._autoResumeTimer = null;
+      const gid = state.reader.gid;
+      if (gid > 0) saveReadingPosition(gid, currentIdx());
+      // Clean up preloaded images
+      state.reader.pages = [];
+      readerSlideWrap.innerHTML = '';
+      state.reader.currentImg = null;
+      state.reader.nextImg = null;
+      state.reader.zoom = 1;
+      state.reader.panX = 0;
+      state.reader.panY = 0;
+      readerEl.classList.remove('open');
+      readerEl.setAttribute('aria-hidden', 'true');
+      if (state.reader.fullscreen && document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {});
+      }
+    }
+
+    // ── UI updates ──
+    function updateReaderUI() {
+      const pages = state.reader.pages;
+      const idx = currentIdx();
+      const total = pages.length;
+      infoProgressEl.textContent = total ? `${idx + 1} / ${total}` : '0 / 0';
+      seekPageTextEl.textContent = total ? `${idx + 1} / ${total}` : '0 / 0';
+      seekRangeEl.max = Math.max(0, total - 1);
+      seekRangeEl.value = idx;
+    }
+
+    function updateReadingProgress() {
+      if (!state.reader._debounceTimer) {
+        state.reader._debounceTimer = setTimeout(() => {
+          state.reader._debounceTimer = null;
+          const gid = state.reader.gid;
+          if (gid > 0) saveReadingPosition(gid, currentIdx());
+        }, 2000);
+      }
+    }
+
+    // ── Info overlay: clock + battery ──
+    function startClock() {
+      stopClock();
+      const tick = () => {
+        const now = new Date();
+        const hh = String(now.getHours()).padStart(2, '0');
+        const mm = String(now.getMinutes()).padStart(2, '0');
+        infoClockEl.textContent = `${hh}:${mm}`;
+      };
+      tick();
+      state.reader.clockTimer = setInterval(tick, 1000);
+    }
+
+    function stopClock() {
+      if (state.reader.clockTimer) { clearInterval(state.reader.clockTimer); state.reader.clockTimer = null; }
+    }
+
+    async function updateBattery() {
+      try {
+        if (navigator.getBattery) {
+          const bat = await navigator.getBattery();
+          const pct = Math.round(bat.level * 100);
+          const icon = bat.charging ? '⚡' : (pct > 80 ? '🔋' : pct > 40 ? '🔋' : pct > 15 ? '🪫' : '⚠');
+          infoBatteryEl.textContent = `${icon} ${pct}%`;
+          bat.addEventListener('levelchange', updateBattery);
+          bat.addEventListener('chargingchange', updateBattery);
+        } else {
+          infoBatteryEl.textContent = '';
+        }
+      } catch (_) { infoBatteryEl.textContent = ''; }
+    }
+
+    // ── Seek bar panel ──
+    function toggleSeekPanel() {
+      const visible = seekPanelEl.classList.toggle('visible');
+      resetSeekHideTimer();
+    }
+
+    function resetSeekHideTimer() {
+      clearTimeout(state.reader.seekHideTimer);
+      if (seekPanelEl.classList.contains('visible')) {
+        state.reader.seekHideTimer = setTimeout(() => {
+          seekPanelEl.classList.remove('visible');
+        }, 3000);
+      }
+    }
+
+    // ── Auto-transfer ──
+    function startAutoTransfer(intervalSec) {
+      stopAutoTransfer();
+      state.reader.autoTransfer = true;
+      state.reader.autoTransferInterval = intervalSec;
+      saveReaderSettings();
+      seekAutoBtn.classList.add('active');
+      seekAutoBtn.textContent = '⏸';
+      state.reader.autoTransferTimer = setInterval(() => {
+        const idx = currentIdx();
+        if (idx >= pageCount() - 1) {
+          stopAutoTransfer();
+          return;
+        }
+        nextPage();
+      }, intervalSec * 1000);
+    }
+
+    function stopAutoTransfer() {
+      if (state.reader.autoTransferTimer) {
+        clearInterval(state.reader.autoTransferTimer);
+        state.reader.autoTransferTimer = null;
+      }
+      if (state.reader._autoResumeTimer) {
+        clearTimeout(state.reader._autoResumeTimer);
+        state.reader._autoResumeTimer = null;
+      }
+      state.reader.autoTransfer = false;
+      seekAutoBtn.classList.remove('active');
+      seekAutoBtn.textContent = '▶';
+      saveReaderSettings();
+    }
+
+    function toggleAutoTransfer() {
+      if (state.reader.autoTransfer) {
+        stopAutoTransfer();
+      } else {
+        startAutoTransfer(state.reader.autoTransferInterval);
+      }
+    }
+
+    function pauseAutoTransferOnInteraction() {
+      if (state.reader.autoTransfer) {
+        // Pause briefly, then resume
+        stopAutoTransfer();
+        state.reader._autoResumeTimer = setTimeout(() => {
+          state.reader._autoResumeTimer = null;
+          startAutoTransfer(state.reader.autoTransferInterval);
+        }, 3000);
+      }
+    }
+
+    // ── Settings dialog ──
+    function openSettingsDialog() {
+      removeDialog();
+      const overlay = document.createElement('div');
+      overlay.className = 'reader-dialog-overlay';
+      overlay.id = 'readerDialogOverlay';
+
+      const at = state.reader.autoTransfer;
+      const atInt = state.reader.autoTransferInterval;
+
+      overlay.innerHTML = `
+        <div class="reader-dialog">
+          <h3>Reader Settings</h3>
+          <div class="setting-row">
+            <label>Reading Direction</label>
+            <select id="dlgDirection">
+              <option value="rtl" ${state.reader.readingDirection === 'rtl' ? 'selected' : ''}>Right-to-Left (Manga)</option>
+              <option value="ltr" ${state.reader.readingDirection === 'ltr' ? 'selected' : ''}>Left-to-Right</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label>Swap Tap/Swipe</label>
+            <button class="toggle ${state.reader.swapTap ? 'on' : ''}" id="dlgSwap"></button>
+          </div>
+          <div class="setting-row">
+            <label>Page Scaling</label>
+            <select id="dlgScaleMode">
+              <option value="fit" ${state.reader.scaleMode === 'fit' ? 'selected' : ''}>Fit</option>
+              <option value="fitWidth" ${state.reader.scaleMode === 'fitWidth' ? 'selected' : ''}>Fit Width</option>
+              <option value="fitHeight" ${state.reader.scaleMode === 'fitHeight' ? 'selected' : ''}>Fit Height</option>
+              <option value="fixed" ${state.reader.scaleMode === 'fixed' ? 'selected' : ''}>Fixed</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label>Fullscreen</label>
+            <button class="toggle ${state.reader.fullscreen ? 'on' : ''}" id="dlgFullscreen"></button>
+          </div>
+          <div class="setting-row">
+            <label>Auto-Transfer</label>
+            <button class="toggle ${at ? 'on' : ''}" id="dlgAutoTransfer"></button>
+          </div>
+          <div class="setting-row">
+            <label>Interval</label>
+            <select id="dlgInterval">
+              <option value="1" ${atInt === 1 ? 'selected' : ''}>1s</option>
+              <option value="2" ${atInt === 2 ? 'selected' : ''}>2s</option>
+              <option value="3" ${atInt === 3 ? 'selected' : ''}>3s</option>
+              <option value="5" ${atInt === 5 ? 'selected' : ''}>5s</option>
+            </select>
+          </div>
+          <div class="dialog-actions">
+            <button id="dlgShortcuts">Keyboard Shortcuts</button>
+            <button id="dlgCloseReader" class="btn-accent">Close Reader</button>
+          </div>
+        </div>
+      `;
+
+      document.body.appendChild(overlay);
+
+      // Event handlers
+      overlay.addEventListener('click', (e) => { if (e.target === overlay) removeDialog(); });
+
+      const toggleBtn = (id, getter, setter) => {
+        const btn = document.getElementById(id);
+        if (!btn) return;
+        btn.addEventListener('click', () => {
+          const val = !getter();
+          setter(val);
+          btn.classList.toggle('on', val);
+          saveReaderSettings();
+          if (id === 'dlgFullscreen') toggleFullscreen();
+        });
+      };
+
+      toggleBtn('dlgSwap', () => state.reader.swapTap, (v) => { state.reader.swapTap = v; });
+      toggleBtn('dlgFullscreen', () => state.reader.fullscreen, (v) => { state.reader.fullscreen = v; });
+      toggleBtn('dlgAutoTransfer', () => state.reader.autoTransfer, (v) => { v ? startAutoTransfer(state.reader.autoTransferInterval) : stopAutoTransfer(); });
+
+      document.getElementById('dlgDirection').addEventListener('change', (e) => {
+        state.reader.readingDirection = e.target.value;
+        saveReaderSettings();
+      });
+      document.getElementById('dlgScaleMode').addEventListener('change', (e) => {
+        state.reader.scaleMode = e.target.value;
+        state.reader.zoom = 1; state.reader.panX = 0; state.reader.panY = 0;
+        saveReaderSettings();
+        const img = state.reader.currentImg;
+        if (img) { applyScaleMode(img); applyZoomAndPan(img); }
+      });
+      document.getElementById('dlgInterval').addEventListener('change', (e) => {
+        state.reader.autoTransferInterval = Number(e.target.value);
+        saveReaderSettings();
+        if (state.reader.autoTransfer) startAutoTransfer(state.reader.autoTransferInterval);
+      });
+      document.getElementById('dlgShortcuts').addEventListener('click', showShortcuts);
+      document.getElementById('dlgCloseReader').addEventListener('click', () => { removeDialog(); closeReader(); });
+    }
+
+    function removeDialog() {
+      const existing = document.getElementById('readerDialogOverlay');
+      if (existing) existing.remove();
+    }
+
+    // ── Fullscreen ──
+    async function toggleFullscreen() {
+      if (state.reader.fullscreen) {
+        try { await readerEl.requestFullscreen(); } catch (_) {}
+      } else if (document.fullscreenElement) {
+        try { await document.exitFullscreen(); } catch (_) {}
+      }
+    }
+
+    // ── Keyboard shortcuts ──
+    function showShortcuts() {
+      removeDialog();
+      const existing = document.getElementById('shortcutsOverlay');
+      if (existing) { existing.remove(); return; }
+      const overlay = document.createElement('div');
+      overlay.className = 'shortcuts-overlay';
+      overlay.id = 'shortcutsOverlay';
+      overlay.innerHTML = `
+        <div class="shortcuts-table">
+          <h3>Keyboard Shortcuts</h3>
+          <table>
+            <tr><td>← ↑ PageUp</td><td>Previous page</td></tr>
+            <tr><td>→ ↓ PageDown</td><td>Next page</td></tr>
+            <tr><td>Space</td><td>Next page</td></tr>
+            <tr><td>Home</td><td>First page</td></tr>
+            <tr><td>End</td><td>Last page</td></tr>
+            <tr><td>M</td><td>Settings menu</td></tr>
+            <tr><td>F</td><td>Toggle fullscreen</td></tr>
+            <tr><td>Esc</td><td>Hide controls / Close reader</td></tr>
+          </table>
+        </div>
+      `;
+      document.body.appendChild(overlay);
+      overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+      document.addEventListener('keydown', function closeShortcuts(e) {
+        if (e.key === 'Escape') { overlay.remove(); document.removeEventListener('keydown', closeShortcuts); }
+      });
+    }
+
+    // ── Unified pointer handling (1 finger = swipe, 2 fingers = pinch + pan) ──
+    // Modeled after iOS Books app: two-finger gestures for zoom/pan, one finger always swipes.
+    //
+    // Critical: never modify img.style.transform in pointerdown — that destroys existing
+    // zoom/pan and causes a visual bounce when the second finger arrives for a pinch.
+    readerStageEl._activePointers = new Map();
+
+    function getPinchDist(p1, p2) {
+      const dx = p1.x - p2.x;
+      const dy = p1.y - p2.y;
+      return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    function getPinchMid(p1, p2) {
+      return { x: (p1.x + p2.x) / 2, y: (p1.y + p2.y) / 2 };
+    }
+
+    readerStageEl.addEventListener('pointerdown', (e) => {
+      if (!isReaderOpen()) return;
+      e.preventDefault();
+      readerStageEl._activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      pauseAutoTransferOnInteraction();
+      resetSeekHideTimer();
+
+      const count = readerStageEl._activePointers.size;
+
+      if (count === 1) {
+        // Potential swipe: record start. DOM is not touched yet — the adjacent
+        // image is positioned on the first pointermove once direction is known.
+        state.reader.isDragging = true;
+        state.reader._adjacentImg = null;
+        state.reader._adjacentIdx = -1;
+        state.reader.dragStartX = e.clientX;
+        state.reader.dragStartY = e.clientY;
+        state.reader.dragDeltaX = 0;
+      } else if (count === 2) {
+        // Second finger → pinch. Cancel drag and clean up any adjacent image.
+        state.reader.isDragging = false;
+        _removeAdjacent();
+        state.reader.pinchActive = true;
+        const img = state.reader.currentImg;
+        if (img) img.style.transition = 'none';
+        const pts = [...readerStageEl._activePointers.values()];
+        state.reader.pinchStartDist = getPinchDist(pts[0], pts[1]);
+        state.reader.pinchStartScale = state.reader.zoom;
+        const mid = getPinchMid(pts[0], pts[1]);
+        state.reader.pinchLastMid = mid;
+      }
+    });
+
+    function _removeAdjacent() {
+      const adj = state.reader._adjacentImg;
+      if (adj && adj.parentNode) adj.remove();
+      state.reader._adjacentImg = null;
+      state.reader._adjacentIdx = -1;
+    }
+
+    function _ensureAdjacent(dx) {
+      const stepWidth = readerStageEl.clientWidth;
+      const absDx = Math.abs(dx);
+      if (absDx < 3) return; // too early to tell direction
+
+      // Determine forward direction
+      const isLTR = state.reader.readingDirection === 'ltr';
+      const swapped = state.reader.swapTap;
+      let forward;
+      if (isLTR) forward = dx < 0;
+      else forward = dx > 0;
+      if (swapped) forward = !forward;
+
+      const newAdjIdx = currentIdx() + (forward ? 1 : -1);
+      const pages = state.reader.pages;
+
+      // Invalid or already showing this adjacent page?
+      if (newAdjIdx < 0 || newAdjIdx >= pages.length) {
+        _removeAdjacent();
+        return;
+      }
+      if (newAdjIdx === state.reader._adjacentIdx) return;
+
+      // Swap adjacent image
+      _removeAdjacent();
+      const adj = pages[newAdjIdx].img;
+      applyScaleMode(adj);
+      adj.style.transition = 'none';
+      // Adjacent side: RTL forward → left (−), LTR forward → right (+)
+      const offset = (forward === isLTR) ? stepWidth : -stepWidth;
+      adj.style.transform = `translateX(${dx + offset}px)`;
+      adj.style.zIndex = '0';
+      if (state.reader.currentImg) state.reader.currentImg.style.zIndex = '1';
+      readerSlideWrap.appendChild(adj);
+      state.reader._adjacentImg = adj;
+      state.reader._adjacentIdx = newAdjIdx;
+      state.reader._adjacentOffset = offset;
+    }
+
+    readerStageEl.addEventListener('pointermove', (e) => {
+      if (!isReaderOpen()) return;
+      e.preventDefault();
+
+      if (readerStageEl._activePointers.has(e.pointerId)) {
+        readerStageEl._activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      }
+
+      const count = readerStageEl._activePointers.size;
+
+      if (count >= 2 && state.reader.pinchActive) {
+        // ── Two-finger pinch zoom + pan (1:1 with finger movement) ──
+        const pts = [...readerStageEl._activePointers.values()];
+        if (pts.length >= 2) {
+          const dist = getPinchDist(pts[0], pts[1]);
+          const scale = Math.min(5, Math.max(0.5,
+            state.reader.pinchStartScale * (dist / state.reader.pinchStartDist)));
+          state.reader.zoom = scale;
+
+          const mid = getPinchMid(pts[0], pts[1]);
+          state.reader.panX += mid.x - state.reader.pinchLastMid.x;
+          state.reader.panY += mid.y - state.reader.pinchLastMid.y;
+          state.reader.pinchLastMid = mid;
+
+          const img = state.reader.currentImg;
+          if (img) applyZoomAndPan(img);
+        }
+      } else if (count === 1 && state.reader.isDragging) {
+        // ── One-finger drag: current + adjacent image move as a seamless strip ──
+        const dx = e.clientX - state.reader.dragStartX;
+        state.reader.dragDeltaX = dx;
+        _ensureAdjacent(dx);
+
+        const img = state.reader.currentImg;
+        if (img && !state.reader.nextImg) {
+          img.style.transition = 'none';
+          img.style.transform = `translateX(${dx}px)`;
+        }
+        const adj = state.reader._adjacentImg;
+        if (adj) {
+          adj.style.transition = 'none';
+          adj.style.transform = `translateX(${dx + state.reader._adjacentOffset}px)`;
+        }
+      }
+    });
+
+    readerStageEl.addEventListener('pointerup', (e) => {
+      if (!isReaderOpen()) return;
+      readerStageEl._activePointers.delete(e.pointerId);
+
+      const count = readerStageEl._activePointers.size;
+
+      // Pinch ended?
+      if (count < 2 && state.reader.pinchActive) {
+        state.reader.pinchActive = false;
+        state.reader.isDragging = false;
+        const img = state.reader.currentImg;
+        if (img && !state.reader.nextImg) applyZoomAndPan(img);
+      }
+
+      // Swipe commit: all fingers lifted, was dragging
+      if (count === 0 && state.reader.isDragging) {
+        state.reader.isDragging = false;
+        const dx = state.reader.dragDeltaX;
+        const absDx = Math.abs(dx);
+        const img = state.reader.currentImg;
+
+        if (absDx < 5) {
+          _removeAdjacent();
+          if (img && !state.reader.nextImg) applyZoomAndPan(img);
+          return;
+        }
+
+        if (absDx > 50 && state.reader._adjacentIdx >= 0) {
+          // Commit: snap current image back to origin instantly, remove adjacent,
+          // then let navigateToPage → showPageSlide handle the sole smooth animation.
+          const targetIdx = state.reader._adjacentIdx;
+          if (img) {
+            img.style.transition = 'none';
+            img.style.transform = 'translateX(0px)';
+          }
+          _removeAdjacent();
+          navigateToPage(targetIdx, dx > 0 ? 1 : -1);
+        } else {
+          // Spring back: animate both images back to origin
+          _removeAdjacent();
+          if (img) {
+            img.style.transition = 'transform 200ms ease-out';
+            applyZoomAndPan(img);
+          }
+        }
+      }
+    });
+
+    readerStageEl.addEventListener('pointercancel', (e) => {
+      readerStageEl._activePointers.delete(e.pointerId);
+      if (readerStageEl._activePointers.size < 2) {
+        state.reader.pinchActive = false;
+      }
+      if (state.reader.isDragging) {
+        state.reader.isDragging = false;
+        _removeAdjacent();
+        const img = state.reader.currentImg;
+        if (img && !state.reader.nextImg) applyZoomAndPan(img);
+      }
+    });
+
+    // ── Ctrl+Wheel zoom ──
+    readerStageEl.addEventListener('wheel', (e) => {
+      if (!isReaderOpen()) return;
+      if (e.ctrlKey) {
+        e.preventDefault();
+        const delta = -e.deltaY * 0.005;
+        const newZoom = Math.min(5, Math.max(0.5, state.reader.zoom + delta));
+        state.reader.zoom = newZoom;
+        const img = state.reader.currentImg;
+        if (img) applyZoomAndPan(img);
+      } else {
+        e.preventDefault(); // block scroll-through
+      }
+    }, { passive: false });
+
+    // ── Double-tap to reset zoom ──
+    readerStageEl.addEventListener('dblclick', (e) => {
+      if (!isReaderOpen()) return;
+      state.reader.zoom = 1;
+      state.reader.panX = 0;
+      state.reader.panY = 0;
+      const img = state.reader.currentImg;
+      if (img) {
+        img.style.transition = 'transform 300ms ease-out';
+        applyZoomAndPan(img);
+      }
+    });
+
+    // ── Tap zone handlers ──
+    function setupTapZone(el, handler) {
+      let downX = 0, downY = 0;
+      el.addEventListener('pointerdown', (e) => { downX = e.clientX; downY = e.clientY; });
+      el.addEventListener('pointerup', (e) => {
+        const dx = e.clientX - downX;
+        const dy = e.clientY - downY;
+        if (Math.abs(dx) < 5 && Math.abs(dy) < 5) {
+          handler(e);
+        }
+      });
+    }
+
+    setupTapZone(zoneLeftEl, () => {
+      navigateToPage(currentIdx() + getEffectiveNext(), 1);
+    });
+    setupTapZone(zoneRightEl, () => {
+      navigateToPage(currentIdx() + getEffectivePrev(), -1);
+    });
+    setupTapZone(zoneMenuEl, () => openSettingsDialog());
+    setupTapZone(zoneSliderEl, () => toggleSeekPanel());
+
+    // ── Seek bar events ──
+    seekRangeEl.addEventListener('input', () => {
+      const val = Number(seekRangeEl.value);
+      seekPageTextEl.textContent = `${val + 1} / ${pageCount()}`;
+    });
+    seekRangeEl.addEventListener('change', () => {
+      const val = Number(seekRangeEl.value);
+      navigateToPage(val, null); // instant jump
+      resetSeekHideTimer();
+    });
+    seekAutoBtn.addEventListener('click', toggleAutoTransfer);
+
+    // ── Close button ──
+    readerCloseBtn.addEventListener('click', closeReader);
+
+    // ── Keyboard navigation ──
+    document.addEventListener('keydown', (event) => {
+      if (!isReaderOpen()) return;
+      const key = event.key;
+
+      // Settings dialog or shortcuts open → only Escape works
+      if (document.getElementById('readerDialogOverlay') || document.getElementById('shortcutsOverlay')) {
+        if (key === 'Escape') {
+          removeDialog();
+          const sc = document.getElementById('shortcutsOverlay');
+          if (sc) sc.remove();
+        }
+        return;
+      }
+
+      switch (key) {
+        case 'ArrowLeft':
+        case 'ArrowUp':
+        case 'PageUp':
+          event.preventDefault();
+          navigateToPage(currentIdx() + getEffectivePrev(), -1);
+          break;
+        case 'ArrowRight':
+        case 'ArrowDown':
+        case 'PageDown':
+          event.preventDefault();
+          navigateToPage(currentIdx() + getEffectiveNext(), 1);
+          break;
+        case ' ':
+          event.preventDefault();
+          navigateToPage(currentIdx() + getEffectiveNext(), 1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          navigateToPage(0, null);
+          break;
+        case 'End':
+          event.preventDefault();
+          navigateToPage(pageCount() - 1, null);
+          break;
+        case 'm':
+        case 'M':
+          event.preventDefault();
+          openSettingsDialog();
+          break;
+        case 'f':
+        case 'F':
+          event.preventDefault();
+          state.reader.fullscreen = !state.reader.fullscreen;
+          saveReaderSettings();
+          toggleFullscreen();
+          break;
+        case 'Escape':
+          event.preventDefault();
+          if (seekPanelEl.classList.contains('visible')) {
+            seekPanelEl.classList.remove('visible');
+          } else {
+            closeReader();
+          }
+          break;
+      }
+      resetSeekHideTimer();
+    });
+
+    // ── Click-outside-zoomed to reset ──
+    readerEl.addEventListener('click', (e) => {
+      if (!isReaderOpen()) return;
+      if (Math.abs(state.reader.zoom - 1) < 0.001) return;
+      // If click is on the reader backdrop itself, not on the image
+      if (e.target === readerEl || e.target === readerStageEl) {
+        state.reader.zoom = 1;
+        state.reader.panX = 0;
+        state.reader.panY = 0;
+        const img = state.reader.currentImg;
+        if (img) {
+          img.style.transition = 'transform 300ms ease-out';
+          applyZoomAndPan(img);
+        }
+      }
+    });
+
+    async function fetchBrowse(path) {
+      syncStateFromInputs();
+      const params = new URLSearchParams();
+      params.set('path', path || '');
+      params.set('version', '2');
+      params.set('include_thumbnails', 'true');
+      if (state.filters.label) params.set('label', state.filters.label);
+      const tags = parseTagsInput(state.filters.tags);
+      if (tags.length) params.set('tags', tags.join(','));
+      if (state.filters.search) params.set('search', state.filters.search);
+      params.set('limit', String(state.limit));
+      params.set('page', String(state.page));
+      const response = await fetch(`/api/browse?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
+    }
+
+    async function load(path) {
+      state.loading = true;
+      render();
+      try {
+        const data = await fetchBrowse(path);
+        state.path = data.currentPath || '';
+        const items = Array.isArray(data.items) ? data.items : [];
+        state.rows = items;
+        const paging = data.pagination || {};
+        const total = Number(paging.total || items.length || 0);
+        const pageCount = Number(paging.pageCount || 1);
+        state.totalItems = Number.isFinite(total) ? total : items.length;
+        state.totalPages = Math.max(1, Number.isFinite(pageCount) ? Math.floor(pageCount) : 1);
+        if (state.page > state.totalPages) state.page = state.totalPages;
+
+        updateLabelOptions(data.availableLabels);
+        updateUrlState();
+      } catch (error) {
+        state.rows = [];
+        emptyEl.style.display = 'block';
+        emptyEl.innerHTML = `<b>Failed to load.</b><br/>${escapeHtml(error.message || String(error))}`;
+      } finally {
+        state.loading = false;
+        render();
+      }
+    }
+
+    function scheduleRealtimeApply() {
+      clearTimeout(state.pendingInputTimer);
+      state.pendingInputTimer = setTimeout(() => {
+        resetToFirstPage();
+        load(state.path);
+      }, 230);
+    }
+
+    parseInitialUrlState();
+    syncInputsFromState();
+    setMode(state.mode);
+
+    applyBtn.addEventListener('click', () => {
+      resetToFirstPage();
+      load(state.path);
+    });
+    clearBtn.addEventListener('click', () => {
+      state.filters.label = '';
+      state.filters.tags = '';
+      state.filters.search = '';
+      resetToFirstPage();
+      syncInputsFromState();
+      load(state.path);
+    });
+    gridBtn.addEventListener('click', () => setMode('grid'));
+    listBtn.addEventListener('click', () => setMode('list'));
+    labelEl.addEventListener('change', () => {
+      resetToFirstPage();
+      load(state.path);
+    });
+    tagsEl.addEventListener('change', () => {
+      resetToFirstPage();
+      load(state.path);
+    });
+    searchEl.addEventListener('input', scheduleRealtimeApply);
+
+    prevPageBtn.addEventListener('click', () => {
+      if (state.page <= 1) return;
+      state.page -= 1;
+      load(state.path);
+    });
+    nextPageBtn.addEventListener('click', () => {
+      if (state.page >= state.totalPages) return;
+      state.page += 1;
+      load(state.path);
+    });
+
+    load(state.path);
+  </script>
+</body>
+</html>

--- a/app/src/main/assets/server/index.html
+++ b/app/src/main/assets/server/index.html
@@ -45,9 +45,31 @@
     }
     .toolbar {
       display: grid;
-      grid-template-columns: minmax(160px, 220px) minmax(180px, 240px) minmax(220px, 1fr) auto auto auto;
+      grid-template-columns: minmax(140px, 200px) minmax(160px, 1fr) auto auto;
       gap: 8px;
       align-items: center;
+    }
+    .tag-toggles {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      margin-top: 8px;
+    }
+    .tag-toggle {
+      border: 1px solid var(--border);
+      background: var(--surface);
+      border-radius: 999px;
+      padding: 3px 11px;
+      font-size: 12px;
+      cursor: pointer;
+      color: var(--muted);
+      user-select: none;
+      transition: all 0.15s;
+    }
+    .tag-toggle.on {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
     }
     .input, .select, button {
       border: 1px solid var(--border);
@@ -136,6 +158,11 @@
     .items.grid {
       grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
     }
+    /* Thumbnail size variants */
+    .items.grid.thumb-small { grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); }
+    .items.grid.thumb-small .thumb-wrap { aspect-ratio: 2/3; }
+    .items.grid.thumb-large { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
+    .items.grid.thumb-large .thumb-wrap { aspect-ratio: 2/3; }
     .item {
       background: var(--surface);
       border: 1px solid var(--border);
@@ -255,6 +282,11 @@
       color: var(--muted);
       min-width: 44px;
       text-align: right;
+    }
+    .item-time {
+      font-size: 10px;
+      color: var(--muted);
+      white-space: nowrap;
     }
     .tag-row {
       display: none;
@@ -745,6 +777,16 @@
         background: #141e28;
         border-color: #2a3a4a;
       }
+      .tag-toggle {
+        border-color: #3a5060;
+        background: #1a2835;
+        color: #889aad;
+      }
+      .tag-toggle.on {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
     }
   </style>
 </head>
@@ -753,16 +795,10 @@
     <div class="panel">
       <div class="toolbar">
         <select id="label" class="select">
-          <option value="">All labels</option>
         </select>
-        <input id="tags" class="input" placeholder="Tags: manga,doujin" />
-        <input id="search" class="input" placeholder="Search title or tags" />
-        <button id="applyBtn" class="btn-primary">Apply</button>
-        <button id="clearBtn" class="btn-soft">Clear</button>
-        <div class="modes">
-          <button id="gridBtn" class="mode">Grid</button>
-          <button id="listBtn" class="mode">List</button>
-        </div>
+        <input id="search" class="input" placeholder="Search title, tags, uploader" />
+        <button id="applyBtn" class="btn-primary">Search</button>
+        <button id="settingsBtn" class="btn-soft">Settings</button>
       </div>
       <div id="path" class="path">/</div>
       <div id="status" class="status">
@@ -806,12 +842,9 @@
     const statusTextEl = document.getElementById('statusText');
     const pagerTextEl = document.getElementById('pagerText');
     const labelEl = document.getElementById('label');
-    const tagsEl = document.getElementById('tags');
     const searchEl = document.getElementById('search');
     const applyBtn = document.getElementById('applyBtn');
-    const clearBtn = document.getElementById('clearBtn');
-    const gridBtn = document.getElementById('gridBtn');
-    const listBtn = document.getElementById('listBtn');
+    const settingsBtn = document.getElementById('settingsBtn');
     const prevPageBtn = document.getElementById('prevPageBtn');
     const nextPageBtn = document.getElementById('nextPageBtn');
     const readerEl = document.getElementById('reader');
@@ -832,10 +865,27 @@
     const seekAutoBtn = document.getElementById('seekAutoBtn');
 
     // ── Global state ──
+    const TAG_CATEGORIES = [
+      { value: 'misc', label: 'Misc' },
+      { value: 'doujinshi', label: 'Doujinshi' },
+      { value: 'manga', label: 'Manga' },
+      { value: 'artistcg', label: 'Artist CG' },
+      { value: 'gamecg', label: 'Game CG' },
+      { value: 'imageset', label: 'Image Set' },
+      { value: 'cosplay', label: 'Cosplay' },
+      { value: 'asianporn', label: 'Asian Porn' },
+      { value: 'non-h', label: 'Non-H' },
+      { value: 'western', label: 'Western' },
+    ];
+
     const state = {
       path: '',
       mode: localStorage.getItem('lan_mode') || 'grid',
-      filters: { label: '', tags: '', search: '' },
+      filters: { label: '', tags: '', search: '', sort: 'modified', order: '' },
+      activeTags: [],
+      // Display settings
+      pageLimit: Number(localStorage.getItem('lan_limit')) || 120,
+      thumbSize: localStorage.getItem('lan_thumb') || 'normal',  // 'small' | 'normal' | 'large'
       rows: [],
       loading: false,
       pendingInputTimer: 0,
@@ -933,9 +983,12 @@
     function parseInitialUrlState() {
       const params = new URLSearchParams(location.search);
       state.path = params.get('path') || '';
-      state.filters.label = params.get('label') || (params.has('label') ? '' : 'Default');
+      state.filters.label = params.get('label') || 'Default';
       state.filters.tags = params.get('tags') || '';
       state.filters.search = params.get('search') || '';
+      state.filters.sort = params.get('sort') || 'modified';
+      state.filters.order = params.get('order') || '';
+      state.activeTags = state.filters.tags ? state.filters.tags.split(',').map(t => t.trim()).filter(Boolean) : [];
       const page = Number(params.get('page') || '1');
       state.page = Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1;
       const mode = params.get('mode');
@@ -950,6 +1003,8 @@
       if (state.filters.label) params.set('label', state.filters.label);
       if (state.filters.tags) params.set('tags', state.filters.tags);
       if (state.filters.search) params.set('search', state.filters.search);
+      if (state.filters.sort && state.filters.sort !== 'modified') params.set('sort', state.filters.sort);
+      if (state.filters.order) params.set('order', state.filters.order);
       params.set('page', String(state.page));
       params.set('mode', state.mode);
       history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
@@ -959,8 +1014,11 @@
       state.mode = mode === 'list' ? 'list' : 'grid';
       localStorage.setItem('lan_mode', state.mode);
       itemsEl.className = `items ${state.mode}`;
-      gridBtn.classList.toggle('active', state.mode === 'grid');
-      listBtn.classList.toggle('active', state.mode === 'list');
+      if (state.mode === 'grid') {
+        itemsEl.classList.remove('thumb-small', 'thumb-large');
+        if (state.thumbSize === 'small') itemsEl.classList.add('thumb-small');
+        if (state.thumbSize === 'large') itemsEl.classList.add('thumb-large');
+      }
       updateUrlState();
       render();
     }
@@ -971,16 +1029,24 @@
     }
 
     function syncInputsFromState() {
+      _updatingLabel = true;
       labelEl.value = state.filters.label;
-      tagsEl.value = state.filters.tags;
+      _updatingLabel = false;
       searchEl.value = state.filters.search;
     }
 
     function syncStateFromInputs() {
-      state.filters.label = labelEl.value.trim();
-      state.filters.tags = tagsEl.value.trim();
+      // Only sync label from the dropdown if it has been populated (options loaded).
+      // On first load the <select> is empty and .value is '',
+      // which would overwrite the default 'Default' label filter.
+      if (labelEl.options.length > 0) {
+        state.filters.label = labelEl.value.trim();
+      }
       state.filters.search = searchEl.value.trim();
+      state.filters.tags = state.activeTags.join(',');
     }
+
+    // ── Tag toggles (rendered inside settings popup only) ──
 
     function resetToFirstPage() {
       state.page = 1;
@@ -999,8 +1065,18 @@
     }
 
     function fmtTime(ts) {
-      if (!ts || ts < 1) return '-';
-      return new Date(ts).toLocaleString();
+      // ts is download time (epoch millis from DownloadInfo.time / item.modified).
+      // 0 means the time was never set (e.g. items added before the time column existed,
+      // or restored via WiFi transfer with a zero timestamp).
+      if (!ts || ts < 1) return 'Unknown';
+      const d = new Date(ts);
+      const yyyy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      const hh = String(d.getHours()).padStart(2, '0');
+      const min = String(d.getMinutes()).padStart(2, '0');
+      const ss = String(d.getSeconds()).padStart(2, '0');
+      return `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss}`;
     }
 
     function escapeHtml(text) {
@@ -1055,6 +1131,7 @@
     function cardMarkup(item) {
       const { safeTitle } = itemMeta(item);
       const uploader = escapeHtml(item.uploader || '-');
+      const timeStr = fmtTime(item.modified);
       return `
         <article class="item" data-path="${escapeHtml(item.path || '')}" data-dir="${item.directory ? '1' : '0'}">
           <div class="thumb-wrap">${itemThumb(item)}</div>
@@ -1065,6 +1142,7 @@
               ${uploader !== '-' ? `<span class="badge">${escapeHtml(uploader)}</span>` : ''}
             </div>
             ${progressMarkup(item.readProgress, item.pageCount)}
+            <div class="item-time">${escapeHtml(timeStr)}</div>
           </div>
         </article>
       `;
@@ -1074,12 +1152,13 @@
       const { safeTitle } = itemMeta(item);
       const uploader = escapeHtml(item.uploader || '-');
       const sizeStr = item.directory ? 'Folder' : fmtSize(item.size);
+      const timeStr = fmtTime(item.modified);
       return `
         <article class="row" data-path="${escapeHtml(item.path || '')}" data-dir="${item.directory ? '1' : '0'}">
           <div class="thumb-wrap">${itemThumb(item)}</div>
           <div class="row-info">
             <div class="row-title">${safeTitle}</div>
-            <div class="row-sub">${uploader !== '-' ? escapeHtml(uploader) : sizeStr}</div>
+            <div class="row-sub">${uploader !== '-' ? escapeHtml(uploader) : sizeStr} · ${escapeHtml(timeStr)}</div>
             <div>${stars(item.rating)}</div>
             ${progressMarkup(item.readProgress, item.pageCount)}
           </div>
@@ -1087,30 +1166,26 @@
       `;
     }
 
+    let _updatingLabel = false;
+
     function updateLabelOptions(availableLabels) {
-      // Only rebuild the dropdown when the available labels actually change,
-      // not on every filter change. This ensures users can switch labels
-      // without being forced back to "All labels" first.
       const labels = Array.isArray(availableLabels) ? availableLabels : [];
       if (labels.length === 0) return;
-      // Build full option list: "All labels" (no filter) + all available labels
-      const fullOptions = ['', ...labels];
-      const currentValue = labelEl.value;
+      const fullOptions = labels;
       const isRebuildNeeded = labelEl.options.length !== fullOptions.length
         || fullOptions.some((l, i) => labelEl.options[i]?.value !== l);
+      _updatingLabel = true;
       if (!isRebuildNeeded) {
-        // Just update the selected value without rebuilding
-        const selected = fullOptions.includes(state.filters.label) ? state.filters.label : '';
+        const selected = fullOptions.includes(state.filters.label) ? state.filters.label : fullOptions[0] || '';
         labelEl.value = selected;
-        return;
+      } else {
+        labelEl.innerHTML = fullOptions.map(l => {
+          return `<option value="${escapeHtml(l)}">${escapeHtml(l)}</option>`;
+        }).join('');
+        const selected = fullOptions.includes(state.filters.label) ? state.filters.label : fullOptions[0] || '';
+        labelEl.value = selected;
       }
-      labelEl.innerHTML = fullOptions.map(l => {
-        if (l === '') return '<option value="">All labels</option>';
-        return `<option value="${escapeHtml(l)}">${escapeHtml(l)}</option>`;
-      }).join('');
-      const selected = fullOptions.includes(state.filters.label) ? state.filters.label : '';
-      labelEl.value = selected;
-      if (!labelEl.value) state.filters.label = '';
+      _updatingLabel = false;
     }
 
     function render() {
@@ -1994,10 +2069,11 @@
       params.set('version', '2');
       params.set('include_thumbnails', 'true');
       if (state.filters.label) params.set('label', state.filters.label);
-      const tags = parseTagsInput(state.filters.tags);
-      if (tags.length) params.set('tags', tags.join(','));
+      if (state.filters.tags) params.set('tags', state.filters.tags);
       if (state.filters.search) params.set('search', state.filters.search);
-      params.set('limit', String(state.limit));
+      if (state.filters.sort && state.filters.sort !== 'modified') params.set('sort', state.filters.sort);
+      if (state.filters.order) params.set('order', state.filters.order);
+      params.set('limit', String(state.pageLimit));
       params.set('page', String(state.page));
       const response = await fetch(`/api/browse?${params.toString()}`);
       if (!response.ok) {
@@ -2041,6 +2117,143 @@
       }, 230);
     }
 
+    // ── Settings popup ──
+    function toggleSettingsPopup() {
+      const existing = document.getElementById('settingsPopup');
+      if (existing) { existing.remove(); return; }
+      renderSettingsPopup();
+    }
+
+    function renderSettingsPopup() {
+      const existing = document.getElementById('settingsPopup');
+      if (existing) existing.remove();
+
+      const overlay = document.createElement('div');
+      overlay.className = 'reader-dialog-overlay';
+      overlay.id = 'settingsPopup';
+      overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+
+      overlay.innerHTML = `
+        <div class="reader-dialog" style="max-width:380px">
+          <h3>Display & Filter Settings</h3>
+          <div class="setting-row">
+            <label>View Mode</label>
+            <select id="popupMode">
+              <option value="grid" ${state.mode === 'grid' ? 'selected' : ''}>Grid</option>
+              <option value="list" ${state.mode === 'list' ? 'selected' : ''}>List</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label>Items per page</label>
+            <select id="popupLimit">
+              <option value="60" ${state.pageLimit === 60 ? 'selected' : ''}>60</option>
+              <option value="120" ${state.pageLimit === 120 ? 'selected' : ''}>120</option>
+              <option value="240" ${state.pageLimit === 240 ? 'selected' : ''}>240</option>
+              <option value="480" ${state.pageLimit === 480 ? 'selected' : ''}>480</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label>Thumbnail Size</label>
+            <select id="popupThumb">
+              <option value="small" ${state.thumbSize === 'small' ? 'selected' : ''}>Small</option>
+              <option value="normal" ${state.thumbSize === 'normal' ? 'selected' : ''}>Normal</option>
+              <option value="large" ${state.thumbSize === 'large' ? 'selected' : ''}>Large</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label>Sort By</label>
+            <select id="popupSort">
+              <option value="modified" ${state.filters.sort === 'modified' && !state.filters.order ? 'selected' : ''}>Download Order ↓</option>
+              <option value="modified_asc" ${state.filters.sort === 'modified' && state.filters.order === 'asc' ? 'selected' : ''}>Download Order ↑</option>
+              <option value="title" ${state.filters.sort === 'title' && !state.filters.order ? 'selected' : ''}>Title A-Z</option>
+              <option value="title_asc" ${state.filters.sort === 'title' && state.filters.order === 'asc' ? 'selected' : ''}>Title Z-A</option>
+              <option value="rating" ${state.filters.sort === 'rating' && !state.filters.order ? 'selected' : ''}>Rating ↓</option>
+              <option value="rating_asc" ${state.filters.sort === 'rating' && state.filters.order === 'asc' ? 'selected' : ''}>Rating ↑</option>
+              <option value="pageCount" ${state.filters.sort === 'pageCount' ? 'selected' : ''}>Pages ↓</option>
+              <option value="size" ${state.filters.sort === 'size' ? 'selected' : ''}>Size ↓</option>
+            </select>
+          </div>
+          <div class="setting-row" style="flex-direction:column;align-items:stretch;gap:6px">
+            <label>Category Filters</label>
+            <div id="popupTags" class="tag-toggles" style="margin-top:0"></div>
+          </div>
+          <div class="dialog-actions" style="margin-top:12px">
+            <button id="popupClear" style="flex:1">Clear All</button>
+            <button id="popupApply" class="btn-accent" style="flex:1">Apply</button>
+          </div>
+        </div>
+      `;
+      document.body.appendChild(overlay);
+
+      // Wire popup events
+      document.getElementById('popupMode').addEventListener('change', (e) => setMode(e.target.value));
+      document.getElementById('popupSort').addEventListener('change', () => {
+        const val = document.getElementById('popupSort').value;
+        if (val.endsWith('_asc')) {
+          state.filters.sort = val.replace('_asc', '');
+          state.filters.order = 'asc';
+        } else {
+          state.filters.sort = val;
+          state.filters.order = '';
+        }
+        updateUrlState();
+      });
+      document.getElementById('popupApply').addEventListener('click', () => {
+        const newLimit = Number(document.getElementById('popupLimit').value);
+        const newThumb = document.getElementById('popupThumb').value;
+        if (newLimit !== state.pageLimit) {
+          state.pageLimit = newLimit;
+          state.limit = newLimit;
+          localStorage.setItem('lan_limit', String(newLimit));
+        }
+        if (newThumb !== state.thumbSize) {
+          state.thumbSize = newThumb;
+          localStorage.setItem('lan_thumb', newThumb);
+        }
+        overlay.remove();
+        resetToFirstPage();
+        load(state.path);
+      });
+      document.getElementById('popupClear').addEventListener('click', () => {
+        const defaultLabel = labelEl.options[0]?.value || '';
+        state.filters.label = defaultLabel;
+        state.filters.tags = '';
+        state.filters.search = '';
+        state.filters.sort = 'modified';
+        state.filters.order = '';
+        state.activeTags = [];
+        state.pageLimit = 120;
+        state.limit = 120;
+        state.thumbSize = 'normal';
+        localStorage.removeItem('lan_limit');
+        localStorage.removeItem('lan_thumb');
+        _updatingLabel = true;
+        labelEl.value = defaultLabel;
+        _updatingLabel = false;
+        searchEl.value = '';
+        overlay.remove();
+        resetToFirstPage();
+        syncInputsFromState();
+        load(state.path);
+      });
+
+      // Render tag toggles inside popup
+      const popupTagContainer = document.getElementById('popupTags');
+      popupTagContainer.innerHTML = TAG_CATEGORIES.map(cat => {
+        const on = state.activeTags.includes(cat.value);
+        return `<span class="tag-toggle${on ? ' on' : ''}" data-tag="${escapeHtml(cat.value)}">${escapeHtml(cat.label)}</span>`;
+      }).join('');
+      popupTagContainer.querySelectorAll('.tag-toggle').forEach(el => {
+        el.addEventListener('click', () => {
+          const tag = el.getAttribute('data-tag');
+          const idx = state.activeTags.indexOf(tag);
+          if (idx >= 0) state.activeTags.splice(idx, 1);
+          else state.activeTags.push(tag);
+          renderSettingsPopup(); // re-render to update toggles
+        });
+      });
+    }
+
     parseInitialUrlState();
     syncInputsFromState();
     setMode(state.mode);
@@ -2049,21 +2262,9 @@
       resetToFirstPage();
       load(state.path);
     });
-    clearBtn.addEventListener('click', () => {
-      state.filters.label = '';
-      state.filters.tags = '';
-      state.filters.search = '';
-      resetToFirstPage();
-      syncInputsFromState();
-      load(state.path);
-    });
-    gridBtn.addEventListener('click', () => setMode('grid'));
-    listBtn.addEventListener('click', () => setMode('list'));
+    settingsBtn.addEventListener('click', toggleSettingsPopup);
     labelEl.addEventListener('change', () => {
-      resetToFirstPage();
-      load(state.path);
-    });
-    tagsEl.addEventListener('change', () => {
+      if (_updatingLabel) return;
       resetToFirstPage();
       load(state.path);
     });

--- a/app/src/main/assets/server/index.html
+++ b/app/src/main/assets/server/index.html
@@ -1254,30 +1254,39 @@
       }
 
       applyScaleMode(newImg);
-      // Position new image off-screen, respecting reading direction
       // In RTL: forward → new page comes from LEFT; in LTR: forward → new page comes from RIGHT
       const isLTR = state.reader.readingDirection === 'ltr';
       const slideDir = direction * (isLTR ? 1 : -1);
+
+      // Position new image off-screen
       newImg.style.transition = 'none';
       newImg.style.transform = `translateX(${slideDir * 100}%)`;
-      newImg.style.zIndex = '1';  // incoming on top
+      newImg.style.opacity = '1';
+      newImg.style.zIndex = '1';
       if (!newImg.parentNode) readerSlideWrap.appendChild(newImg);
+
+      // Reset old image to origin (unzoomed, centered) in case drag offset it
+      if (oldImg) {
+        oldImg.style.transition = 'none';
+        oldImg.style.transform = 'translateX(0px)';
+        oldImg.style.opacity = '1';
+        oldImg.style.zIndex = '0';
+      }
 
       // Force reflow
       newImg.offsetHeight;
 
-      // Animate only the incoming image; remove outgoing instantly
+      // Animate: new slides in, old slides out + fades out — both move as one strip
       if (oldImg) {
-        oldImg.style.transition = 'none';
-        oldImg.style.transform = '';
-        if (oldImg.parentNode) oldImg.remove();
+        oldImg.style.transition = 'transform 200ms ease-out, opacity 150ms ease-in';
+        oldImg.style.transform = `translateX(${-slideDir * 100}%)`;
+        oldImg.style.opacity = '0';
       }
       newImg.style.transition = 'transform 200ms ease-out';
       newImg.style.transform = 'translateX(0)';
 
       state.reader.nextImg = newImg;
 
-      // On transition end, clean up
       const onEnd = () => {
         newImg.removeEventListener('transitionend', onEnd);
         if (oldImg && oldImg.parentNode) oldImg.remove();

--- a/app/src/main/assets/server/index.html
+++ b/app/src/main/assets/server/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>EhViewer LAN Browser</title>
   <style>
     :root {
@@ -118,9 +118,6 @@
       background: var(--accent-soft);
       color: #06564a;
       font-weight: 700;
-    }
-    .path {
-      display: none; /* hidden: not needed for indexed (non-path-based) browsing */
     }
     .status {
       margin-top: 8px;
@@ -288,17 +285,6 @@
       color: var(--muted);
       white-space: nowrap;
     }
-    .tag-row {
-      display: none;
-    }
-    .tag {
-      font-size: 11px;
-      background: #fff5e9;
-      border: 1px solid #f4d8bd;
-      color: #8d5a29;
-      border-radius: 999px;
-      padding: 1px 7px;
-    }
     .row {
       display: none;
       grid-template-columns: 68px 1fr;
@@ -414,6 +400,43 @@
       display: grid;
       grid-template-rows: 1fr;
       grid-template-columns: 1fr;
+    }
+    /* Fullscreen: override the fixed+inset layout so the reader fills the entire
+       fullscreen context. Padding respects the device safe areas (status bar,
+       home indicator) so content doesn't overlap system UI. */
+    .reader:fullscreen,
+    .reader:-webkit-full-screen {
+      position: static;
+      width: 100%;
+      height: 100%;
+      display: grid;
+      grid-template-rows: 1fr;
+      grid-template-columns: 1fr;
+      padding-top: env(safe-area-inset-top, 0px);
+      padding-bottom: env(safe-area-inset-bottom, 0px);
+      padding-left: env(safe-area-inset-left, 0px);
+      padding-right: env(safe-area-inset-right, 0px);
+    }
+    /* Ensure all interior containers stretch fully within the padded area */
+    .reader:fullscreen .reader-stage,
+    .reader:-webkit-full-screen .reader-stage,
+    .reader:fullscreen .reader-slide-wrap,
+    .reader:-webkit-full-screen .reader-slide-wrap {
+      width: 100%;
+      height: 100%;
+    }
+    /* Nudge overlays so they sit just inside the safe area rather than under it */
+    .reader:fullscreen .reader-info,
+    .reader:-webkit-full-screen .reader-info {
+      padding-top: env(safe-area-inset-top, 0px);
+    }
+    .reader:fullscreen .reader-close,
+    .reader:-webkit-full-screen .reader-close {
+      top: calc(8px + env(safe-area-inset-top, 0px));
+    }
+    .reader:fullscreen .reader-seek-panel,
+    .reader:-webkit-full-screen .reader-seek-panel {
+      padding-bottom: env(safe-area-inset-bottom, 0px);
     }
 
     /* ── Info Overlay Bar ── */
@@ -614,6 +637,8 @@
     }
     .reader-dialog .toggle {
       width: 44px; height: 24px;
+      min-height: 24px;
+      padding: 0;
       border-radius: 12px;
       background: rgba(255,255,255,0.15);
       position: relative;
@@ -739,11 +764,6 @@
         background: #1a2a35;
         color: #90b8c8;
       }
-      .tag {
-        background: #2a1f15;
-        border-color: #5a4030;
-        color: #c89660;
-      }
       .btn-soft {
         border-color: #3a5060;
         background: #1a2835;
@@ -800,7 +820,6 @@
         <button id="applyBtn" class="btn-primary">Search</button>
         <button id="settingsBtn" class="btn-soft">Settings</button>
       </div>
-      <div id="path" class="path">/</div>
       <div id="status" class="status">
         <span id="statusText"></span>
         <span class="pager">
@@ -851,7 +870,6 @@
     const readerStageEl = document.getElementById('readerStage');
     const readerCloseBtn = document.getElementById('readerCloseBtn');
     const readerSlideWrap = document.getElementById('readerSlideWrap');
-    const readerInfoEl = document.getElementById('readerInfo');
     const infoClockEl = document.getElementById('infoClock');
     const infoProgressEl = document.getElementById('infoProgress');
     const infoBatteryEl = document.getElementById('infoBattery');
@@ -890,7 +908,6 @@
       loading: false,
       pendingInputTimer: 0,
       page: 1,
-      limit: 120,
       totalPages: 1,
       totalItems: 0,
       reader: {
@@ -899,8 +916,6 @@
         pages: [],           // array of { url, name } preloaded Image elements stored as .img
         index: 0,
         // settings (persisted)
-        readingDirection: 'rtl',    // 'rtl' or 'ltr'
-        swapTap: false,
         scaleMode: 'fit',           // 'fit' | 'fitWidth' | 'fitHeight' | 'fixed'
         fullscreen: false,
         autoTransfer: false,
@@ -908,14 +923,12 @@
         // runtime
         currentImg: null,   // reference to the currently displayed <img>
         nextImg: null,      // reference to the next <img> for slide animation
-        controlsVisible: false,
         zoom: 1,            // current zoom scale (1 = fit)
         panX: 0,            // current pan offset X
         panY: 0,            // current pan offset Y
         autoTransferTimer: null,
         clockTimer: null,
         seekHideTimer: null,
-        controlsHideTimer: null,
         isDragging: false,
         dragStartX: 0,
         dragStartY: 0,
@@ -937,8 +950,6 @@
         const raw = localStorage.getItem(READER_SETTINGS_KEY);
         if (raw) {
           const s = JSON.parse(raw);
-          state.reader.readingDirection = s.readingDirection || 'rtl';
-          state.reader.swapTap = !!s.swapTap;
           state.reader.scaleMode = s.scaleMode || 'fit';
           state.reader.fullscreen = !!s.fullscreen;
           state.reader.autoTransfer = !!s.autoTransfer;
@@ -949,8 +960,6 @@
 
     function saveReaderSettings() {
       localStorage.setItem(READER_SETTINGS_KEY, JSON.stringify({
-        readingDirection: state.reader.readingDirection,
-        swapTap: state.reader.swapTap,
         scaleMode: state.reader.scaleMode,
         fullscreen: state.reader.fullscreen,
         autoTransfer: state.reader.autoTransfer,
@@ -979,6 +988,16 @@
     }
 
     loadReaderSettings();
+
+    // When the user exits fullscreen via a browser gesture (e.g. iPad swipe or Esc),
+    // turn off the preference so the toggle reflects reality and the next reader
+    // open won't auto-enter fullscreen.
+    document.addEventListener('fullscreenchange', () => {
+      if (!document.fullscreenElement && readerEl.classList.contains('open')) {
+        state.reader.fullscreen = false;
+        saveReaderSettings();
+      }
+    });
 
     function parseInitialUrlState() {
       const params = new URLSearchParams(location.search);
@@ -1021,11 +1040,6 @@
       }
       updateUrlState();
       render();
-    }
-
-    function parseTagsInput(value) {
-      if (!value) return [];
-      return value.split(',').map(x => x.trim()).filter(Boolean);
     }
 
     function syncInputsFromState() {
@@ -1121,22 +1135,19 @@
       return `<span>${item.directory ? 'DIR' : 'FILE'}</span>`;
     }
 
-    function itemMeta(item) {
-      const tags = Array.isArray(item.tags) ? item.tags.slice(0, 4) : [];
-      const labels = Array.isArray(item.labels) ? item.labels : [];
-      const pages = item.pageCount ? `${item.pageCount}P` : '-';
-      return { tags, labels, pages, safeTitle: escapeHtml(item.title || item.name || 'Untitled') };
+    function safeTitle(item) {
+      return escapeHtml(item.title || item.name || 'Untitled');
     }
 
     function cardMarkup(item) {
-      const { safeTitle } = itemMeta(item);
+      const st = safeTitle(item);
       const uploader = escapeHtml(item.uploader || '-');
       const timeStr = fmtTime(item.modified);
       return `
         <article class="item" data-path="${escapeHtml(item.path || '')}" data-dir="${item.directory ? '1' : '0'}">
           <div class="thumb-wrap">${itemThumb(item)}</div>
           <div class="meta">
-            <h3 class="title" title="${safeTitle}">${safeTitle}</h3>
+            <h3 class="title" title="${st}">${st}</h3>
             <div class="stats">
               ${stars(item.rating)}
               ${uploader !== '-' ? `<span class="badge">${escapeHtml(uploader)}</span>` : ''}
@@ -1149,7 +1160,7 @@
     }
 
     function rowMarkup(item) {
-      const { safeTitle } = itemMeta(item);
+      const st = safeTitle(item);
       const uploader = escapeHtml(item.uploader || '-');
       const sizeStr = item.directory ? 'Folder' : fmtSize(item.size);
       const timeStr = fmtTime(item.modified);
@@ -1157,7 +1168,7 @@
         <article class="row" data-path="${escapeHtml(item.path || '')}" data-dir="${item.directory ? '1' : '0'}">
           <div class="thumb-wrap">${itemThumb(item)}</div>
           <div class="row-info">
-            <div class="row-title">${safeTitle}</div>
+            <div class="row-title">${st}</div>
             <div class="row-sub">${uploader !== '-' ? escapeHtml(uploader) : sizeStr} · ${escapeHtml(timeStr)}</div>
             <div>${stars(item.rating)}</div>
             ${progressMarkup(item.readProgress, item.pageCount)}
@@ -1291,13 +1302,6 @@
       navigateToPage(currentIdx() + 1, 1);
     }
 
-    function getEffectivePrev() {
-      return state.reader.swapTap ? 1 : -1;
-    }
-    function getEffectiveNext() {
-      return state.reader.swapTap ? -1 : 1;
-    }
-
     // ── Slide animation ──
     function showPageInstant(idx) {
       const pages = state.reader.pages;
@@ -1329,9 +1333,8 @@
       }
 
       applyScaleMode(newImg);
-      // In RTL: forward → new page comes from LEFT; in LTR: forward → new page comes from RIGHT
-      const isLTR = state.reader.readingDirection === 'ltr';
-      const slideDir = direction * (isLTR ? 1 : -1);
+      // RTL reading: forward → new page slides in from LEFT
+      const slideDir = -direction;
 
       // Position new image off-screen
       newImg.style.transition = 'none';
@@ -1420,6 +1423,10 @@
         updateReaderUI();
         startClock();
         updateBattery();
+        // Auto-enter fullscreen if the user's preference is enabled
+        if (state.reader.fullscreen && !document.fullscreenElement) {
+          try { await readerEl.requestFullscreen(); } catch (_) {}
+        }
       } catch (error) {
         readerSlideWrap.innerHTML = `<div class="reader-empty">Failed to open reader: ${escapeHtml(error.message || String(error))}</div>`;
       }
@@ -1429,7 +1436,6 @@
       stopAutoTransfer();
       stopClock();
       clearTimeout(state.reader.seekHideTimer);
-      clearTimeout(state.reader.controlsHideTimer);
       clearTimeout(state.reader._debounceTimer);
       clearTimeout(state.reader._autoResumeTimer);
       state.reader._debounceTimer = null;
@@ -1444,11 +1450,16 @@
       state.reader.zoom = 1;
       state.reader.panX = 0;
       state.reader.panY = 0;
-      readerEl.classList.remove('open');
-      readerEl.setAttribute('aria-hidden', 'true');
-      if (state.reader.fullscreen && document.fullscreenElement) {
+      // Always exit fullscreen so the user can interact with the page normally
+      if (document.fullscreenElement) {
         document.exitFullscreen().catch(() => {});
       }
+      // Dismiss any open overlays that may have been hidden behind fullscreen
+      removeDialog();
+      const sc = document.getElementById('shortcutsOverlay');
+      if (sc) sc.remove();
+      readerEl.classList.remove('open');
+      readerEl.setAttribute('aria-hidden', 'true');
     }
 
     // ── UI updates ──
@@ -1561,12 +1572,18 @@
     }
 
     function pauseAutoTransferOnInteraction() {
-      if (state.reader.autoTransfer) {
-        // Pause briefly, then resume
-        stopAutoTransfer();
+      // Pause the interval without toggling the setting or saving to storage
+      if (state.reader.autoTransfer && state.reader.autoTransferTimer) {
+        clearInterval(state.reader.autoTransferTimer);
+        state.reader.autoTransferTimer = null;
+        if (state.reader._autoResumeTimer) clearTimeout(state.reader._autoResumeTimer);
         state.reader._autoResumeTimer = setTimeout(() => {
           state.reader._autoResumeTimer = null;
-          startAutoTransfer(state.reader.autoTransferInterval);
+          state.reader.autoTransferTimer = setInterval(() => {
+            const idx = currentIdx();
+            if (idx >= pageCount() - 1) { stopAutoTransfer(); return; }
+            nextPage();
+          }, state.reader.autoTransferInterval * 1000);
         }, 3000);
       }
     }
@@ -1584,17 +1601,7 @@
       overlay.innerHTML = `
         <div class="reader-dialog">
           <h3>Reader Settings</h3>
-          <div class="setting-row">
-            <label>Reading Direction</label>
-            <select id="dlgDirection">
-              <option value="rtl" ${state.reader.readingDirection === 'rtl' ? 'selected' : ''}>Right-to-Left (Manga)</option>
-              <option value="ltr" ${state.reader.readingDirection === 'ltr' ? 'selected' : ''}>Left-to-Right</option>
-            </select>
-          </div>
-          <div class="setting-row">
-            <label>Swap Tap/Swipe</label>
-            <button class="toggle ${state.reader.swapTap ? 'on' : ''}" id="dlgSwap"></button>
-          </div>
+
           <div class="setting-row">
             <label>Page Scaling</label>
             <select id="dlgScaleMode">
@@ -1645,14 +1652,9 @@
         });
       };
 
-      toggleBtn('dlgSwap', () => state.reader.swapTap, (v) => { state.reader.swapTap = v; });
       toggleBtn('dlgFullscreen', () => state.reader.fullscreen, (v) => { state.reader.fullscreen = v; });
       toggleBtn('dlgAutoTransfer', () => state.reader.autoTransfer, (v) => { v ? startAutoTransfer(state.reader.autoTransferInterval) : stopAutoTransfer(); });
 
-      document.getElementById('dlgDirection').addEventListener('change', (e) => {
-        state.reader.readingDirection = e.target.value;
-        saveReaderSettings();
-      });
       document.getElementById('dlgScaleMode').addEventListener('change', (e) => {
         state.reader.scaleMode = e.target.value;
         state.reader.zoom = 1; state.reader.panX = 0; state.reader.panY = 0;
@@ -1677,6 +1679,12 @@
     // ── Fullscreen ──
     async function toggleFullscreen() {
       if (state.reader.fullscreen) {
+        // Dismiss any open overlays before entering fullscreen so they don't
+        // end up hidden behind the fullscreen element
+        removeDialog();
+        const sc = document.getElementById('shortcutsOverlay');
+        if (sc) sc.remove();
+        seekPanelEl.classList.remove('visible');
         try { await readerEl.requestFullscreen(); } catch (_) {}
       } else if (document.fullscreenElement) {
         try { await document.exitFullscreen(); } catch (_) {}
@@ -1698,6 +1706,8 @@
             <tr><td>← ↑ PageUp</td><td>Previous page</td></tr>
             <tr><td>→ ↓ PageDown</td><td>Next page</td></tr>
             <tr><td>Space</td><td>Next page</td></tr>
+            <tr><td>Tap left / Swipe →</td><td>Next page (RTL)</td></tr>
+            <tr><td>Tap right / Swipe ←</td><td>Previous page (RTL)</td></tr>
             <tr><td>Home</td><td>First page</td></tr>
             <tr><td>End</td><td>Last page</td></tr>
             <tr><td>M</td><td>Settings menu</td></tr>
@@ -1775,13 +1785,8 @@
       const absDx = Math.abs(dx);
       if (absDx < 3) return; // too early to tell direction
 
-      // Determine forward direction
-      const isLTR = state.reader.readingDirection === 'ltr';
-      const swapped = state.reader.swapTap;
-      let forward;
-      if (isLTR) forward = dx < 0;
-      else forward = dx > 0;
-      if (swapped) forward = !forward;
+      // RTL reading: swipe right (dx > 0) = forward
+      const forward = dx > 0;
 
       const newAdjIdx = currentIdx() + (forward ? 1 : -1);
       const pages = state.reader.pages;
@@ -1798,8 +1803,8 @@
       const adj = pages[newAdjIdx].img;
       applyScaleMode(adj);
       adj.style.transition = 'none';
-      // Adjacent side: RTL forward → left (−), LTR forward → right (+)
-      const offset = (forward === isLTR) ? stepWidth : -stepWidth;
+      // RTL forward → adjacent page is on the left (−)
+      const offset = forward ? -stepWidth : stepWidth;
       adj.style.transform = `translateX(${dx + offset}px)`;
       adj.style.zIndex = '0';
       if (state.reader.currentImg) state.reader.currentImg.style.zIndex = '1';
@@ -1958,10 +1963,10 @@
     }
 
     setupTapZone(zoneLeftEl, () => {
-      navigateToPage(currentIdx() + getEffectiveNext(), 1);
+      navigateToPage(currentIdx() + 1, 1);
     });
     setupTapZone(zoneRightEl, () => {
-      navigateToPage(currentIdx() + getEffectivePrev(), -1);
+      navigateToPage(currentIdx() - 1, -1);
     });
     setupTapZone(zoneMenuEl, () => openSettingsDialog());
     setupTapZone(zoneSliderEl, () => toggleSeekPanel());
@@ -2001,17 +2006,17 @@
         case 'ArrowUp':
         case 'PageUp':
           event.preventDefault();
-          navigateToPage(currentIdx() + getEffectivePrev(), -1);
+          navigateToPage(currentIdx() - 1, -1);
           break;
         case 'ArrowRight':
         case 'ArrowDown':
         case 'PageDown':
           event.preventDefault();
-          navigateToPage(currentIdx() + getEffectiveNext(), 1);
+          navigateToPage(currentIdx() + 1, 1);
           break;
         case ' ':
           event.preventDefault();
-          navigateToPage(currentIdx() + getEffectiveNext(), 1);
+          navigateToPage(currentIdx() + 1, 1);
           break;
         case 'Home':
           event.preventDefault();
@@ -2203,7 +2208,6 @@
         const newThumb = document.getElementById('popupThumb').value;
         if (newLimit !== state.pageLimit) {
           state.pageLimit = newLimit;
-          state.limit = newLimit;
           localStorage.setItem('lan_limit', String(newLimit));
         }
         if (newThumb !== state.thumbSize) {
@@ -2223,7 +2227,6 @@
         state.filters.order = '';
         state.activeTags = [];
         state.pageLimit = 120;
-        state.limit = 120;
         state.thumbSize = 'normal';
         localStorage.removeItem('lan_limit');
         localStorage.removeItem('lan_thumb');

--- a/app/src/main/java/com/hippo/ehviewer/EhDB.java
+++ b/app/src/main/java/com/hippo/ehviewer/EhDB.java
@@ -208,10 +208,31 @@ public class EhDB {
                 context.getApplicationContext(), "eh.db", null);
 
         SQLiteDatabase db = helper.getWritableDatabase();
+        ensureServerBrowseIndexes(db);
         DaoMaster daoMaster = new DaoMaster(db);
 
         sDaoSession = daoMaster.newSession();
         MAX_HISTORY_COUNT = Settings.getHistoryInfoSize();
+    }
+
+    /**
+     * Server browse uses label/tag filtering heavily; keep indexes in sync on every startup.
+     */
+    private static void ensureServerBrowseIndexes(@NonNull SQLiteDatabase db) {
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_DOWNLOADS_LABEL ON DOWNLOADS (LABEL)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_ARTIST ON Gallery_Tags (ARTIST)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_ROWS ON Gallery_Tags (ROWS)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_COSPLAYER ON Gallery_Tags (COSPLAYER)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_CHARACTER ON Gallery_Tags (CHARACTER)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_FEMALE ON Gallery_Tags (FEMALE)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_GROUP ON Gallery_Tags (\"GROUP\")");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_LANGUAGE ON Gallery_Tags (LANGUAGE)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_MALE ON Gallery_Tags (MALE)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_MISC ON Gallery_Tags (MISC)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_MIXED ON Gallery_Tags (MIXED)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_OTHER ON Gallery_Tags (OTHER)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_PARODY ON Gallery_Tags (PARODY)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS IDX_GALLERY_TAGS_RECLASS ON Gallery_Tags (RECLASS)");
     }
 
     public static boolean needMerge() {

--- a/app/src/main/java/com/hippo/ehviewer/Settings.java
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.java
@@ -866,6 +866,51 @@ public class Settings {
         putBoolean(KEY_DOWNLOAD_ORIGIN_IMAGE, value);
     }
 
+    public static final String KEY_SERVER_ENABLED = "server_enabled";
+    private static final boolean DEFAULT_SERVER_ENABLED = false;
+
+    public static boolean getServerEnabled() {
+        return getBoolean(KEY_SERVER_ENABLED, DEFAULT_SERVER_ENABLED);
+    }
+
+    public static void putServerEnabled(boolean value) {
+        putBoolean(KEY_SERVER_ENABLED, value);
+    }
+
+    public static final String KEY_SERVER_PORT = "server_port";
+    private static final int DEFAULT_SERVER_PORT = 8080;
+
+    public static int getServerPort() {
+        return getIntFromStr(KEY_SERVER_PORT, DEFAULT_SERVER_PORT);
+    }
+
+    public static void putServerPort(int value) {
+        putIntToStr(KEY_SERVER_PORT, value);
+    }
+
+    private static final String KEY_SERVER_BOUND_PORT = "server_bound_port";
+    private static final int DEFAULT_SERVER_BOUND_PORT = 0;
+
+    public static int getServerBoundPort() {
+        return getInt(KEY_SERVER_BOUND_PORT, DEFAULT_SERVER_BOUND_PORT);
+    }
+
+    public static void putServerBoundPort(int value) {
+        putInt(KEY_SERVER_BOUND_PORT, value);
+    }
+
+    public static final String KEY_SERVER_LOG_LEVEL = "server_log_level";
+    private static final String DEFAULT_SERVER_LOG_LEVEL = "INFO";
+
+    @NonNull
+    public static String getServerLogLevel() {
+        return getString(KEY_SERVER_LOG_LEVEL, DEFAULT_SERVER_LOG_LEVEL);
+    }
+
+    public static void putServerLogLevel(@NonNull String value) {
+        putString(KEY_SERVER_LOG_LEVEL, value);
+    }
+
     /********************
      ****** Favorites
      ********************/

--- a/app/src/main/java/com/hippo/ehviewer/server/api/BrowseFilterUtils.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/api/BrowseFilterUtils.java
@@ -1,0 +1,175 @@
+package com.hippo.ehviewer.server.api;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.hippo.ehviewer.dao.GalleryTags;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+final class BrowseFilterUtils {
+
+    /** The label name used for unlabeled items, matching the in-app default label string. */
+    static final String DEFAULT_LABEL_NAME = "Default";
+
+    private BrowseFilterUtils() {
+    }
+
+    @Nullable
+    static String normalizeFilterValue(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    @NonNull
+    static List<String> parseTagFilters(@Nullable String rawTags) {
+        if (rawTags == null || rawTags.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] split = rawTags.split(",");
+        ArrayList<String> tags = new ArrayList<>(split.length);
+        for (String tag : split) {
+            if (tag == null) {
+                continue;
+            }
+            String trimmed = tag.trim();
+            if (!trimmed.isEmpty()) {
+                tags.add(trimmed);
+            }
+        }
+        return tags;
+    }
+
+    static boolean matchesLabel(@NonNull List<String> labels, @NonNull String labelFilter) {
+        // "Default" matches items that have no label (empty labels list),
+        // matching the in-app download page behavior for unlabeled items.
+        if (DEFAULT_LABEL_NAME.equalsIgnoreCase(labelFilter.trim())) {
+            return labels.isEmpty();
+        }
+        for (String label : labels) {
+            if (equalsIgnoreCase(label, labelFilter)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean matchesTags(@NonNull List<String> tags, @NonNull List<String> filters) {
+        for (String filter : filters) {
+            for (String tag : tags) {
+                if (matchSingleTag(tag, filter)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static boolean matchesSearch(@Nullable String title,
+                                 @NonNull List<String> labels,
+                                 @NonNull List<String> tags,
+                                 @NonNull String searchFilter) {
+        if (containsIgnoreCase(title, searchFilter)) {
+            return true;
+        }
+        for (String label : labels) {
+            if (containsIgnoreCase(label, searchFilter)) {
+                return true;
+            }
+        }
+        for (String tag : tags) {
+            if (containsIgnoreCase(tag, searchFilter)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean matchSingleTag(@Nullable String tag, @Nullable String searchTag) {
+        if (tag == null || searchTag == null) {
+            return false;
+        }
+        String normalizedTag = tag.trim().toLowerCase(Locale.ROOT);
+        String normalizedSearchTag = searchTag.trim().toLowerCase(Locale.ROOT);
+        if (normalizedTag.isEmpty() || normalizedSearchTag.isEmpty()) {
+            return false;
+        }
+
+        int tagIndex = normalizedTag.indexOf(':');
+        String tagNamespace = tagIndex >= 0 ? normalizedTag.substring(0, tagIndex) : null;
+        String tagName = tagIndex >= 0 ? normalizedTag.substring(tagIndex + 1) : normalizedTag;
+
+        int searchIndex = normalizedSearchTag.indexOf(':');
+        String searchNamespace = searchIndex >= 0 ? normalizedSearchTag.substring(0, searchIndex) : null;
+        String searchName = searchIndex >= 0 ? normalizedSearchTag.substring(searchIndex + 1) : normalizedSearchTag;
+
+        if (searchNamespace != null && (tagNamespace == null || !tagNamespace.equals(searchNamespace))) {
+            return false;
+        }
+
+        return tagName.equals(searchName) || tagName.contains(searchName);
+    }
+
+    @NonNull
+    static List<String> extractTags(@Nullable GalleryTags galleryTags) {
+        if (galleryTags == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> output = new ArrayList<>();
+        addNamespacedTags(output, "artist", galleryTags.artist);
+        addNamespacedTags(output, "rows", galleryTags.rows);
+        addNamespacedTags(output, "cosplayer", galleryTags.cosplayer);
+        addNamespacedTags(output, "character", galleryTags.character);
+        addNamespacedTags(output, "female", galleryTags.female);
+        addNamespacedTags(output, "group", galleryTags.group);
+        addNamespacedTags(output, "language", galleryTags.language);
+        addNamespacedTags(output, "male", galleryTags.male);
+        addNamespacedTags(output, "misc", galleryTags.misc);
+        addNamespacedTags(output, "mixed", galleryTags.mixed);
+        addNamespacedTags(output, "other", galleryTags.other);
+        addNamespacedTags(output, "parody", galleryTags.parody);
+        addNamespacedTags(output, "reclass", galleryTags.reclass);
+        return output;
+    }
+
+    private static void addNamespacedTags(@NonNull List<String> output,
+                                          @NonNull String namespace,
+                                          @Nullable String csvTags) {
+        if (csvTags == null || csvTags.isEmpty()) {
+            return;
+        }
+        String[] split = csvTags.split(",");
+        for (String value : split) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = value.trim();
+            if (!trimmed.isEmpty()) {
+                output.add(namespace + ":" + trimmed);
+            }
+        }
+    }
+
+    private static boolean equalsIgnoreCase(@Nullable String value, @Nullable String target) {
+        if (value == null || target == null) {
+            return false;
+        }
+        return value.trim().equalsIgnoreCase(target.trim());
+    }
+
+    private static boolean containsIgnoreCase(@Nullable String value, @Nullable String query) {
+        if (value == null || query == null) {
+            return false;
+        }
+        String normalizedValue = value.toLowerCase(Locale.ROOT);
+        String normalizedQuery = query.toLowerCase(Locale.ROOT);
+        return normalizedValue.contains(normalizedQuery);
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/api/SimpleHttpServer.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/api/SimpleHttpServer.java
@@ -243,6 +243,8 @@ public final class SimpleHttpServer {
         String labelFilter = BrowseFilterUtils.normalizeFilterValue(query.get("label"));
         List<String> tagFilters = BrowseFilterUtils.parseTagFilters(query.get("tags"));
         String searchFilter = BrowseFilterUtils.normalizeFilterValue(query.get("search"));
+        String sortField = BrowseFilterUtils.normalizeFilterValue(query.get("sort"));
+        String sortOrder = BrowseFilterUtils.normalizeFilterValue(query.get("order"));
         Pagination pagination;
         try {
             pagination = parsePagination(query.get("page"), query.get("limit"));
@@ -252,7 +254,7 @@ public final class SimpleHttpServer {
         }
 
         if (version >= API_VERSION_V2) {
-            serveBrowseV2Indexed(os, path, includeThumbnails, labelFilter, tagFilters, searchFilter, pagination);
+            serveBrowseV2Indexed(os, path, includeThumbnails, labelFilter, tagFilters, searchFilter, sortField, sortOrder, pagination);
             return;
         }
 
@@ -342,6 +344,8 @@ public final class SimpleHttpServer {
                                       @Nullable String labelFilter,
                                       @NonNull List<String> tagFilters,
                                       @Nullable String searchFilter,
+                                      @Nullable String sortField,
+                                      @Nullable String sortOrder,
                                       @NonNull Pagination pagination) throws IOException {
         String normalizedPath = PathValidator.normalizePath(path);
         if (!normalizedPath.isEmpty()) {
@@ -365,7 +369,35 @@ public final class SimpleHttpServer {
             browseItems.add(item);
         }
 
-        browseItems.sort((a, b) -> Long.compare(b.modified, a.modified));
+        // Sort only when an explicit sort field is requested.
+        // When no sort is specified, preserve the in-app download order from
+        // getAllDownloadInfoList() (which reflects drag-reorder adjustments).
+        if (sortField != null) {
+            boolean ascending = "asc".equalsIgnoreCase(sortOrder != null ? sortOrder : "");
+            Comparator<BrowseItem> itemComparator;
+            if ("title".equalsIgnoreCase(sortField)) {
+                Comparator<BrowseItem> c = Comparator.comparing(
+                        i -> i.metadata != null && i.metadata.title != null ? i.metadata.title.toLowerCase() : "");
+                itemComparator = ascending ? c : c.reversed();
+            } else if ("rating".equalsIgnoreCase(sortField)) {
+                Comparator<BrowseItem> c = Comparator.comparing(
+                        i -> i.metadata != null && i.metadata.rating != null ? i.metadata.rating : 0f);
+                itemComparator = ascending ? c : c.reversed();
+            } else if ("pageCount".equalsIgnoreCase(sortField)) {
+                Comparator<BrowseItem> c = Comparator.comparing(
+                        i -> i.metadata != null && i.metadata.pageCount != null ? i.metadata.pageCount : 0);
+                itemComparator = ascending ? c : c.reversed();
+            } else if ("size".equalsIgnoreCase(sortField)) {
+                Comparator<BrowseItem> c = Comparator.comparing(i -> i.size);
+                itemComparator = ascending ? c : c.reversed();
+            } else {
+                // Explicit "modified" sort requested
+                itemComparator = (a, b) -> ascending
+                        ? Long.compare(a.modified, b.modified)
+                        : Long.compare(b.modified, a.modified);
+            }
+            browseItems.sort(itemComparator);
+        }
 
         List<BrowseItem> pageItems = browseItems;
         if (pagination.enabled) {
@@ -431,9 +463,14 @@ public final class SimpleHttpServer {
                 ? Collections.emptyList()
                 : Collections.singletonList(info.label);
         metadata.tags = extractIndexedTags(info);
-        metadata.uploader = TextUtils.isEmpty(info.uploader) ? "-" : info.uploader;
+        // Include category in tags so tag toggles can filter by category
         String categoryText = EhUtils.getCategory(info.category);
         metadata.category = TextUtils.isEmpty(categoryText) ? "-" : categoryText;
+        if (!TextUtils.isEmpty(categoryText) && !metadata.tags.contains(categoryText)) {
+            metadata.tags = new ArrayList<>(metadata.tags);
+            metadata.tags.add(0, categoryText);
+        }
+        metadata.uploader = TextUtils.isEmpty(info.uploader) ? "-" : info.uploader;
 
         metadata.thumbnailUrl = includeThumbnails ? "/api/thumb?gid=" + info.gid : null;
 

--- a/app/src/main/java/com/hippo/ehviewer/server/api/SimpleHttpServer.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/api/SimpleHttpServer.java
@@ -1,0 +1,1111 @@
+package com.hippo.ehviewer.server.api;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.hippo.ehviewer.EhApplication;
+import com.hippo.ehviewer.EhDB;
+import com.hippo.ehviewer.client.EhUtils;
+import com.hippo.ehviewer.dao.DownloadInfo;
+import com.hippo.ehviewer.dao.DownloadLabel;
+import com.hippo.ehviewer.download.DownloadManager;
+import com.hippo.ehviewer.spider.SpiderDen;
+import com.hippo.ehviewer.spider.SpiderInfo;
+import com.hippo.ehviewer.server.util.ContentTypeUtils;
+import com.hippo.ehviewer.server.util.PathValidator;
+import com.hippo.ehviewer.server.util.ServerLog;
+import com.hippo.unifile.UniFile;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Base64;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public final class SimpleHttpServer {
+
+    private static final int API_VERSION_V2 = 2;
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_LIMIT = 60;
+    private static final int MAX_LIMIT = 300;
+    private static final long MAX_THUMBNAIL_BYTES = 512 * 1024;
+    private final Context context;
+    private final UniFile root;
+    private final int port;
+    private final ExecutorService clientPool = Executors.newCachedThreadPool();
+
+    private volatile boolean running;
+    private ServerSocket serverSocket;
+    private Thread serverThread;
+
+    public SimpleHttpServer(@NonNull Context context, @NonNull UniFile root, int port) {
+        this.context = context.getApplicationContext();
+        this.root = root;
+        this.port = port;
+    }
+
+    public void start() throws IOException {
+        if (running) {
+            return;
+        }
+        running = true;
+        serverSocket = new ServerSocket(port);
+        serverThread = new Thread(this::acceptLoop, "LanServer-Accept");
+        serverThread.start();
+    }
+
+    public void stop() {
+        running = false;
+        if (serverSocket != null) {
+            try {
+                serverSocket.close();
+            } catch (IOException ignored) {
+            }
+        }
+        if (serverThread != null) {
+            serverThread.interrupt();
+        }
+        clientPool.shutdownNow();
+    }
+
+    private void acceptLoop() {
+        while (running && serverSocket != null && !serverSocket.isClosed()) {
+            try {
+                Socket socket = serverSocket.accept();
+                clientPool.execute(() -> handleClient(socket));
+            } catch (IOException e) {
+                if (running) {
+                    ServerLog.e("Accept failed: " + e.getMessage());
+                }
+                break;
+            }
+        }
+    }
+
+    private void handleClient(@NonNull Socket socket) {
+        try (Socket ignored = socket;
+             BufferedInputStream bis = new BufferedInputStream(socket.getInputStream());
+             OutputStream os = socket.getOutputStream()) {
+            try {
+                HttpRequest request = parseRequest(bis);
+                if (request == null) {
+                    return;
+                }
+                if (!"GET".equalsIgnoreCase(request.method)) {
+                    writeText(os, 405, "text/plain; charset=utf-8", "Method Not Allowed");
+                    return;
+                }
+
+                if ("/".equals(request.path) || "/index.html".equals(request.path)) {
+                    serveIndex(os);
+                    return;
+                }
+
+                if ("/api/browse".equals(request.path)) {
+                    serveBrowse(os, request.query);
+                    return;
+                }
+
+                if ("/api/reader".equals(request.path)) {
+                    serveReader(os, request.query);
+                    return;
+                }
+
+                if ("/api/thumb".equals(request.path)) {
+                    serveThumbnail(os, request.query.get("gid"));
+                    return;
+                }
+
+                if ("/api/labels".equals(request.path)) {
+                    serveLabels(os);
+                    return;
+                }
+
+                if (request.path.startsWith("/files/")) {
+                    String relative = request.path.substring("/files/".length());
+                    serveFile(os, relative);
+                    return;
+                }
+
+                writeJson(os, 404, jsonError("not_found", "Path not found"));
+            } catch (Throwable e) {
+                // Return a generic 500 to the client; log details server-side
+                try {
+                    writeJson(os, 500, jsonError("internal_error", "Server error"));
+                } catch (IOException ioe) {
+                    // Ignore write failures after error
+                }
+                ServerLog.e("Request handling error: " + e.getMessage());
+            }
+        } catch (Throwable e) {
+            ServerLog.e("I/O error handling client: " + e.getMessage());
+        }
+    }
+
+    private HttpRequest parseRequest(@NonNull InputStream is) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.US_ASCII));
+        String line = reader.readLine();
+        if (line == null || line.isEmpty()) {
+            return null;
+        }
+        String[] parts = line.split(" ");
+        if (parts.length < 2) {
+            return null;
+        }
+
+        String method = parts[0].trim();
+        String target = parts[1].trim();
+
+        while (true) {
+            String header = reader.readLine();
+            if (header == null || header.isEmpty()) {
+                break;
+            }
+        }
+
+        String path = target;
+        String queryText = "";
+        int q = target.indexOf('?');
+        if (q >= 0) {
+            path = target.substring(0, q);
+            queryText = target.substring(q + 1);
+        }
+
+        HttpRequest request = new HttpRequest();
+        request.method = method;
+        request.path = path;
+        request.query = parseQuery(queryText);
+        return request;
+    }
+
+    @NonNull
+    private Map<String, String> parseQuery(@NonNull String query) {
+        Map<String, String> map = new HashMap<>();
+        if (query.isEmpty()) {
+            return map;
+        }
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int idx = pair.indexOf('=');
+            if (idx < 0) {
+                map.put(decodeComponent(pair), "");
+            } else {
+                map.put(decodeComponent(pair.substring(0, idx)), decodeComponent(pair.substring(idx + 1)));
+            }
+        }
+        return map;
+    }
+
+    @NonNull
+    private String decodeComponent(@NonNull String raw) {
+        try {
+            return URLDecoder.decode(raw, StandardCharsets.UTF_8.name());
+        } catch (Throwable ignored) {
+            return raw;
+        }
+    }
+
+    private void serveIndex(@NonNull OutputStream os) throws IOException {
+        byte[] html = readAsset("server/index.html");
+        writeBytes(os, 200, "text/html; charset=utf-8", html);
+    }
+
+    private void serveBrowse(@NonNull OutputStream os, @NonNull Map<String, String> query) throws IOException {
+        String path = query.get("path");
+        int version = parseVersion(query.get("version"));
+        boolean includeThumbnails = parseBoolean(query.get("include_thumbnails"));
+        String labelFilter = BrowseFilterUtils.normalizeFilterValue(query.get("label"));
+        List<String> tagFilters = BrowseFilterUtils.parseTagFilters(query.get("tags"));
+        String searchFilter = BrowseFilterUtils.normalizeFilterValue(query.get("search"));
+        Pagination pagination;
+        try {
+            pagination = parsePagination(query.get("page"), query.get("limit"));
+        } catch (IllegalArgumentException e) {
+            writeJson(os, 400, jsonError("invalid_request", e.getMessage()));
+            return;
+        }
+
+        if (version >= API_VERSION_V2) {
+            serveBrowseV2Indexed(os, path, includeThumbnails, labelFilter, tagFilters, searchFilter, pagination);
+            return;
+        }
+
+        UniFile target = PathValidator.resolveRelativePath(root, path);
+        if (target == null || !target.exists() || !target.isDirectory()) {
+            ServerLog.e("Rejected browse path: " + path);
+            writeJson(os, 403, jsonError("forbidden", "Invalid browse path"));
+            return;
+        }
+
+        String currentPath = PathValidator.normalizePath(path);
+        JSONObject result = new JSONObject();
+        result.put("currentPath", currentPath);
+        result.put("parentPath", parentPath(currentPath));
+
+        UniFile[] children = target.listFiles();
+        ArrayList<UniFile> rows = new ArrayList<>();
+        if (children != null) {
+            Collections.addAll(rows, children);
+        }
+        rows.sort(Comparator
+                .comparing((UniFile f) -> !f.isDirectory())
+                .thenComparing(f -> {
+                    String name = f.getName();
+                    return name == null ? "" : name.toLowerCase();
+                }));
+
+        MetadataContext metadataContext = version >= API_VERSION_V2
+                ? buildMetadataContext(rows)
+                : MetadataContext.empty();
+
+        ArrayList<BrowseItem> browseItems = new ArrayList<>(rows.size());
+        for (UniFile child : rows) {
+            String name = child.getName();
+            if (name == null) {
+                continue;
+            }
+            String itemPath = currentPath.isEmpty() ? name : currentPath + "/" + name;
+            String mimeType = child.isDirectory() ? "inode/directory" : ContentTypeUtils.fromName(name);
+
+            BrowseMetadata metadata = null;
+            if (version >= API_VERSION_V2) {
+                metadata = resolveMetadata(child, name, metadataContext, includeThumbnails);
+                if (!matchesFilters(metadata, labelFilter, tagFilters, searchFilter)) {
+                    continue;
+                }
+            }
+
+            BrowseItem item = new BrowseItem();
+            item.name = name;
+            item.path = itemPath;
+            item.directory = child.isDirectory();
+            item.size = child.isDirectory() ? 0 : Math.max(0, child.length());
+            item.modified = child.lastModified();
+            item.mimeType = mimeType;
+            item.image = !child.isDirectory() && ContentTypeUtils.isImage(mimeType);
+            item.url = child.isDirectory() ? null : "/files/" + PathValidator.encodePath(itemPath);
+            item.metadata = metadata;
+            browseItems.add(item);
+        }
+
+        List<BrowseItem> pageItems = browseItems;
+        if (pagination.enabled) {
+            int fromIndex = Math.min((pagination.page - 1) * pagination.limit, browseItems.size());
+            int toIndex = Math.min(fromIndex + pagination.limit, browseItems.size());
+            pageItems = browseItems.subList(fromIndex, toIndex);
+            JSONObject pageObject = new JSONObject();
+            pageObject.put("page", pagination.page);
+            pageObject.put("limit", pagination.limit);
+            pageObject.put("total", browseItems.size());
+            pageObject.put("pageCount", browseItems.isEmpty() ? 0 : (int) Math.ceil(browseItems.size() / (double) pagination.limit));
+            result.put("pagination", pageObject);
+        }
+
+        JSONArray items = new JSONArray();
+        for (BrowseItem item : pageItems) {
+            items.add(toJsonItem(item, version));
+        }
+        result.put("items", items);
+
+        writeJson(os, 200, result);
+    }
+
+    private void serveBrowseV2Indexed(@NonNull OutputStream os,
+                                      @Nullable String path,
+                                      boolean includeThumbnails,
+                                      @Nullable String labelFilter,
+                                      @NonNull List<String> tagFilters,
+                                      @Nullable String searchFilter,
+                                      @NonNull Pagination pagination) throws IOException {
+        String normalizedPath = PathValidator.normalizePath(path);
+        if (!normalizedPath.isEmpty()) {
+            writeJson(os, 403, jsonError("forbidden", "Indexed browse only supports root path"));
+            return;
+        }
+
+        JSONObject result = new JSONObject(new LinkedHashMap<>());
+        result.put("currentPath", "");
+        result.put("parentPath", "");
+
+        DownloadManager manager = EhApplication.getDownloadManager(context);
+        List<DownloadInfo> downloads = manager.getAllDownloadInfoList();
+        ArrayList<BrowseItem> browseItems = new ArrayList<>(downloads.size());
+
+        for (DownloadInfo info : downloads) {
+            BrowseItem item = buildIndexedItem(info, includeThumbnails);
+            if (!matchesFilters(item.metadata, labelFilter, tagFilters, searchFilter)) {
+                continue;
+            }
+            browseItems.add(item);
+        }
+
+        browseItems.sort((a, b) -> Long.compare(b.modified, a.modified));
+
+        List<BrowseItem> pageItems = browseItems;
+        if (pagination.enabled) {
+            int fromIndex = Math.min((pagination.page - 1) * pagination.limit, browseItems.size());
+            int toIndex = Math.min(fromIndex + pagination.limit, browseItems.size());
+            pageItems = browseItems.subList(fromIndex, toIndex);
+
+            JSONObject pageObject = new JSONObject();
+            pageObject.put("page", pagination.page);
+            pageObject.put("limit", pagination.limit);
+            pageObject.put("total", browseItems.size());
+            pageObject.put("pageCount", browseItems.isEmpty() ? 0 : (int) Math.ceil(browseItems.size() / (double) pagination.limit));
+            result.put("pagination", pageObject);
+        }
+
+        JSONArray items = new JSONArray();
+        for (BrowseItem item : pageItems) {
+            enrichIndexedReadProgress(item);
+            items.add(toJsonItem(item, API_VERSION_V2));
+        }
+        result.put("items", items);
+
+        JSONObject filters = new JSONObject(new LinkedHashMap<>());
+        if (labelFilter != null) {
+            filters.put("label", labelFilter);
+        }
+        if (!tagFilters.isEmpty()) {
+            filters.put("tags", toJsonArray(tagFilters));
+        }
+        if (searchFilter != null) {
+            filters.put("search", searchFilter);
+        }
+        result.put("filters", filters);
+
+        // Include all available labels (including "Default") so the client
+        // can populate the label dropdown independently of the current filter.
+        JSONArray availableLabels = new JSONArray();
+        availableLabels.add(BrowseFilterUtils.DEFAULT_LABEL_NAME);
+        List<DownloadLabel> labelList = manager.getLabelList();
+        if (labelList != null) {
+            for (DownloadLabel dl : labelList) {
+                if (dl == null || dl.getLabel() == null) continue;
+                String name = dl.getLabel().trim();
+                if (!name.isEmpty() && !BrowseFilterUtils.DEFAULT_LABEL_NAME.equalsIgnoreCase(name)) {
+                    availableLabels.add(name);
+                }
+            }
+        }
+        result.put("availableLabels", availableLabels);
+
+        writeJson(os, 200, result);
+    }
+
+    @NonNull
+    private BrowseItem buildIndexedItem(@NonNull DownloadInfo info, boolean includeThumbnails) {
+        BrowseMetadata metadata = new BrowseMetadata();
+        metadata.title = TextUtils.isEmpty(info.title) ? Long.toString(info.gid) : info.title;
+        metadata.rating = info.rating < 0 ? null : info.rating;
+
+        int inferredPages = info.pages > 0 ? info.pages : info.total;
+        metadata.pageCount = inferredPages > 0 ? inferredPages : null;
+        metadata.labels = TextUtils.isEmpty(info.label)
+                ? Collections.emptyList()
+                : Collections.singletonList(info.label);
+        metadata.tags = extractIndexedTags(info);
+        metadata.uploader = TextUtils.isEmpty(info.uploader) ? "-" : info.uploader;
+        String categoryText = EhUtils.getCategory(info.category);
+        metadata.category = TextUtils.isEmpty(categoryText) ? "-" : categoryText;
+
+        metadata.thumbnailUrl = includeThumbnails ? "/api/thumb?gid=" + info.gid : null;
+
+        BrowseItem item = new BrowseItem();
+        item.gid = info.gid;
+        item.name = metadata.title;
+        item.path = Long.toString(info.gid);
+        item.directory = false;
+        item.size = Math.max(0, info.fileSize);
+        item.modified = info.time;
+        item.mimeType = "application/octet-stream";
+        item.image = false;
+        item.url = "/api/reader?gid=" + info.gid;
+        item.metadata = metadata;
+        return item;
+    }
+
+    private void enrichIndexedReadProgress(@NonNull BrowseItem item) {
+        if (item.gid <= 0 || item.metadata == null) {
+            return;
+        }
+
+        DownloadManager manager = EhApplication.getDownloadManager(context);
+        DownloadInfo info = manager.getDownloadInfo(item.gid);
+        if (info == null) {
+            return;
+        }
+
+        UniFile dir = SpiderDen.getExistingGalleryDownloadDir(info);
+        if (dir == null || !dir.isDirectory()) {
+            return;
+        }
+
+        UniFile spiderFile = dir.findFile(".ehviewer");
+        if (spiderFile == null || !spiderFile.isFile()) {
+            return;
+        }
+
+        SpiderInfo spiderInfo = SpiderInfo.read(spiderFile);
+        if (spiderInfo == null || spiderInfo.pages <= 0) {
+            return;
+        }
+
+        int total = spiderInfo.pages;
+        int current = Math.max(0, Math.min(total, spiderInfo.startPage + 1));
+        JSONObject progress = new JSONObject();
+        progress.put("current", current);
+        progress.put("total", total);
+        item.metadata.readProgress = progress;
+        // Only override pageCount from spiderInfo if the DB-reported pageCount is null/unknown
+        if (item.metadata.pageCount == null || item.metadata.pageCount <= 0) {
+            item.metadata.pageCount = total;
+        }
+    }
+
+    private void serveThumbnail(@NonNull OutputStream os, @Nullable String gidText) throws IOException {
+        long gid = parseGid(gidText);
+        if (gid <= 0) {
+            writeJson(os, 400, jsonError("invalid_request", "gid is required"));
+            return;
+        }
+
+        DownloadManager manager = EhApplication.getDownloadManager(context);
+        DownloadInfo info = manager.getDownloadInfo(gid);
+        if (info == null) {
+            writeJson(os, 404, jsonError("not_found", "item not found"));
+            return;
+        }
+
+        UniFile dir = SpiderDen.getExistingGalleryDownloadDir(info);
+        if (dir == null || !dir.isDirectory()) {
+            writeJson(os, 404, jsonError("not_found", "download dir not found"));
+            return;
+        }
+
+        UniFile thumb = dir.findFile(".thumb");
+        if (thumb == null || !thumb.isFile()) {
+            writeJson(os, 404, jsonError("not_found", "thumbnail not found"));
+            return;
+        }
+
+        long length = Math.max(0, thumb.length());
+        if (length <= 0 || length > MAX_THUMBNAIL_BYTES) {
+            writeJson(os, 404, jsonError("not_found", "thumbnail unavailable"));
+            return;
+        }
+
+        try (InputStream in = thumb.openInputStream();
+             ByteArrayOutputStream bos = new ByteArrayOutputStream((int) length)) {
+            byte[] buffer = new byte[8 * 1024];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                bos.write(buffer, 0, read);
+            }
+            byte[] bytes = bos.toByteArray();
+            if (bytes.length == 0) {
+                writeJson(os, 404, jsonError("not_found", "thumbnail empty"));
+                return;
+            }
+            writeBytes(os, 200, detectImageMimeType(bytes), bytes);
+        }
+    }
+
+    private void serveLabels(@NonNull OutputStream os) throws IOException {
+        DownloadManager manager = EhApplication.getDownloadManager(context);
+        List<DownloadLabel> labelList = manager.getLabelList();
+        JSONArray labels = new JSONArray();
+        // Always include "Default" as the first option for unlabeled items,
+        // matching the in-app download page behavior.
+        labels.add(BrowseFilterUtils.DEFAULT_LABEL_NAME);
+        if (labelList != null) {
+            for (DownloadLabel dl : labelList) {
+                if (dl == null || dl.getLabel() == null) continue;
+                String name = dl.getLabel().trim();
+                if (!name.isEmpty() && !BrowseFilterUtils.DEFAULT_LABEL_NAME.equalsIgnoreCase(name)) {
+                    labels.add(name);
+                }
+            }
+        }
+        JSONObject result = new JSONObject();
+        result.put("labels", labels);
+        writeJson(os, 200, result);
+    }
+
+    private void serveReader(@NonNull OutputStream os, @NonNull Map<String, String> query) throws IOException {
+        long gid = parseGid(query.get("gid"));
+        if (gid <= 0) {
+            writeJson(os, 400, jsonError("invalid_request", "gid is required"));
+            return;
+        }
+
+        DownloadManager manager = EhApplication.getDownloadManager(context);
+        DownloadInfo info = manager.getDownloadInfo(gid);
+        if (info == null) {
+            writeJson(os, 404, jsonError("not_found", "item not found"));
+            return;
+        }
+
+        UniFile dir = SpiderDen.getExistingGalleryDownloadDir(info);
+        if (dir == null || !dir.isDirectory()) {
+            writeJson(os, 404, jsonError("not_found", "download dir not found"));
+            return;
+        }
+
+        UniFile[] files = dir.listFiles();
+        if (files == null) {
+            files = new UniFile[0];
+        }
+
+        ArrayList<UniFile> imageFiles = new ArrayList<>();
+        for (UniFile file : files) {
+            if (!file.isFile()) {
+                continue;
+            }
+            String name = file.getName();
+            if (name == null || name.startsWith(".")) {
+                continue;
+            }
+            String mimeType = ContentTypeUtils.fromName(name);
+            if (ContentTypeUtils.isImage(mimeType)) {
+                imageFiles.add(file);
+            }
+        }
+
+        imageFiles.sort((a, b) -> compareNaturalName(a.getName(), b.getName()));
+
+        String dirName = dir.getName();
+        if (TextUtils.isEmpty(dirName)) {
+            writeJson(os, 404, jsonError("not_found", "download dir name missing"));
+            return;
+        }
+
+        JSONObject result = new JSONObject(new LinkedHashMap<>());
+        result.put("gid", gid);
+        result.put("title", TextUtils.isEmpty(info.title) ? Long.toString(gid) : info.title);
+
+        int startIndex = 0;
+        UniFile spider = dir.findFile(".ehviewer");
+        if (spider != null && spider.isFile()) {
+            SpiderInfo spiderInfo = SpiderInfo.read(spider);
+            if (spiderInfo != null) {
+                startIndex = Math.max(0, spiderInfo.startPage);
+            }
+        }
+
+        JSONArray pages = new JSONArray();
+        for (int i = 0; i < imageFiles.size(); i++) {
+            UniFile image = imageFiles.get(i);
+            String name = image.getName();
+            if (name == null) {
+                continue;
+            }
+            String relativePath = dirName + "/" + name;
+            JSONObject page = new JSONObject();
+            page.put("index", i);
+            page.put("name", name);
+            page.put("url", "/files/" + PathValidator.encodePath(relativePath));
+            pages.add(page);
+        }
+        result.put("pages", pages);
+        result.put("startIndex", Math.min(startIndex, Math.max(0, pages.size() - 1)));
+        writeJson(os, 200, result);
+    }
+
+    private long parseGid(@Nullable String gidText) {
+        if (gidText == null || gidText.isEmpty()) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(gidText.trim());
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private int compareNaturalName(@Nullable String a, @Nullable String b) {
+        String left = a == null ? "" : a;
+        String right = b == null ? "" : b;
+        return left.compareTo(right);
+    }
+
+    @NonNull
+    private List<String> extractIndexedTags(@NonNull DownloadInfo info) {
+        if (info.simpleTags == null) return Collections.emptyList();
+        ArrayList<String> tags = new ArrayList<>(info.simpleTags.length);
+        for (String tag : info.simpleTags) {
+            if (tag == null) continue;
+            String t = tag.trim();
+            if (!t.isEmpty()) tags.add(t);
+        }
+        return tags;
+    }
+
+    @NonNull
+    private JSONObject toJsonItem(@NonNull BrowseItem item, int version) {
+        JSONObject object = new JSONObject(new LinkedHashMap<>());
+        object.put("name", item.name);
+        object.put("path", item.path);
+        object.put("directory", item.directory);
+        object.put("size", item.size);
+        object.put("modified", item.modified);
+        object.put("mimeType", item.mimeType);
+        object.put("image", item.image);
+        object.put("url", item.url);
+        if (version >= API_VERSION_V2) {
+            BrowseMetadata metadata = item.metadata;
+            object.put("title", metadata == null ? item.name : metadata.title);
+            object.put("rating", metadata == null ? null : metadata.rating);
+            object.put("pageCount", metadata == null ? null : metadata.pageCount);
+            object.put("readProgress", metadata == null ? null : metadata.readProgress);
+            object.put("labels", metadata == null ? new JSONArray() : toJsonArray(metadata.labels));
+            object.put("tags", metadata == null ? new JSONArray() : toJsonArray(metadata.tags));
+            object.put("uploader", metadata == null ? "-" : metadata.uploader);
+            object.put("category", metadata == null ? "-" : metadata.category);
+            object.put("thumbnailUrl", metadata == null ? null : metadata.thumbnailUrl);
+        }
+        return object;
+    }
+
+    @NonNull
+    private JSONArray toJsonArray(@NonNull List<String> source) {
+        JSONArray array = new JSONArray(source.size());
+        array.addAll(source);
+        return array;
+    }
+
+    private int parseVersion(@Nullable String rawVersion) {
+        if (rawVersion == null || rawVersion.isEmpty()) {
+            return 1;
+        }
+        try {
+            int parsed = Integer.parseInt(rawVersion);
+            return parsed == API_VERSION_V2 ? API_VERSION_V2 : 1;
+        } catch (NumberFormatException ignored) {
+            return 1;
+        }
+    }
+
+    private boolean parseBoolean(@Nullable String value) {
+        if (value == null) {
+            return false;
+        }
+        return "1".equals(value) || "true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value);
+    }
+
+    @NonNull
+    private Pagination parsePagination(@Nullable String rawPage, @Nullable String rawLimit) {
+        if ((rawPage == null || rawPage.isEmpty()) && (rawLimit == null || rawLimit.isEmpty())) {
+            return Pagination.disabled();
+        }
+
+        int page = DEFAULT_PAGE;
+        int limit = DEFAULT_LIMIT;
+        try {
+            if (rawPage != null && !rawPage.isEmpty()) {
+                page = Integer.parseInt(rawPage.trim());
+            }
+            if (rawLimit != null && !rawLimit.isEmpty()) {
+                limit = Integer.parseInt(rawLimit.trim());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("page and limit must be integers");
+        }
+        if (page < 1) {
+            throw new IllegalArgumentException("page must be >= 1");
+        }
+        if (limit < 1 || limit > MAX_LIMIT) {
+            throw new IllegalArgumentException("limit must be between 1 and " + MAX_LIMIT);
+        }
+
+        return Pagination.enabled(page, limit);
+    }
+
+    @NonNull
+    private MetadataContext buildMetadataContext(@NonNull List<UniFile> rows) {
+        DownloadManager manager = EhApplication.getDownloadManager(context);
+        List<DownloadInfo> downloads = manager.getAllDownloadInfoList();
+        Map<Long, DownloadInfo> byGid = new HashMap<>(downloads.size());
+        Map<String, DownloadInfo> byDirname = new HashMap<>(downloads.size());
+        Set<Long> candidateGids = new LinkedHashSet<>();
+        for (DownloadInfo info : downloads) {
+            byGid.put(info.gid, info);
+            String dirname = EhDB.getDownloadDirname(info.gid);
+            if (!TextUtils.isEmpty(dirname)) {
+                byDirname.put(dirname, info);
+            }
+        }
+
+        for (UniFile row : rows) {
+            if (!row.isDirectory()) {
+                continue;
+            }
+            String name = row.getName();
+            if (name == null) {
+                continue;
+            }
+            DownloadInfo info = byDirname.get(name);
+            if (info == null) {
+                info = byGid.get(parseLeadingGid(name));
+            }
+            if (info != null) {
+                candidateGids.add(info.gid);
+            }
+        }
+
+        Map<Long, List<String>> tagsByGid = new HashMap<>();
+        for (Long gid : candidateGids) {
+            tagsByGid.put(gid, BrowseFilterUtils.extractTags(EhDB.queryGalleryTags(gid)));
+        }
+
+        return new MetadataContext(byGid, byDirname, tagsByGid);
+    }
+
+    @Nullable
+    private BrowseMetadata resolveMetadata(@NonNull UniFile child,
+                                           @NonNull String name,
+                                           @NonNull MetadataContext context,
+                                           boolean includeThumbnails) {
+        if (!child.isDirectory()) {
+            return null;
+        }
+
+        DownloadInfo info = context.byDirname.get(name);
+        if (info == null) {
+            info = context.byGid.get(parseLeadingGid(name));
+        }
+        if (info == null) {
+            return null;
+        }
+
+        BrowseMetadata metadata = new BrowseMetadata();
+        metadata.title = TextUtils.isEmpty(info.title) ? name : info.title;
+        metadata.rating = info.rating < 0 ? null : info.rating;
+        metadata.pageCount = info.pages > 0 ? info.pages : null;
+        metadata.labels = TextUtils.isEmpty(info.label)
+                ? Collections.emptyList()
+                : Collections.singletonList(info.label);
+        metadata.tags = context.tagsByGid.getOrDefault(info.gid, Collections.emptyList());
+        metadata.uploader = TextUtils.isEmpty(info.uploader) ? "-" : info.uploader;
+        String categoryText = EhUtils.getCategory(info.category);
+        metadata.category = TextUtils.isEmpty(categoryText) ? "-" : categoryText;
+        metadata.readProgress = buildReadProgress(child, info.pages);
+        if (metadata.pageCount == null && metadata.readProgress != null) {
+            metadata.pageCount = metadata.readProgress.getInteger("total");
+        }
+        metadata.thumbnailUrl = includeThumbnails ? loadThumbnailAsDataUri(child) : null;
+        return metadata;
+    }
+
+    @Nullable
+    private JSONObject buildReadProgress(@NonNull UniFile directory, int fallbackPageCount) {
+        UniFile spiderFile = directory.findFile(".ehviewer");
+        if (spiderFile == null || !spiderFile.isFile()) {
+            return null;
+        }
+        SpiderInfo spiderInfo = SpiderInfo.read(spiderFile);
+        if (spiderInfo == null) {
+            return null;
+        }
+
+        int total = spiderInfo.pages > 0 ? spiderInfo.pages : fallbackPageCount;
+        if (total <= 0) {
+            return null;
+        }
+        // SpiderInfo.startPage is zero-based; expose 1-based current page when available
+        int current = Math.max(0, Math.min(total, spiderInfo.startPage + 1));
+        JSONObject progress = new JSONObject();
+        progress.put("current", current);
+        progress.put("total", total);
+        return progress;
+    }
+
+    @Nullable
+    private String loadThumbnailAsDataUri(@NonNull UniFile directory) {
+        UniFile thumb = directory.findFile(".thumb");
+        if (thumb == null || !thumb.isFile()) {
+            return null;
+        }
+
+        long length = Math.max(0, thumb.length());
+        if (length == 0 || length > MAX_THUMBNAIL_BYTES) {
+            return null;
+        }
+
+        try (InputStream is = thumb.openInputStream();
+             ByteArrayOutputStream bos = new ByteArrayOutputStream((int) length)) {
+            byte[] buffer = new byte[8 * 1024];
+            int read;
+            while ((read = is.read(buffer)) >= 0) {
+                bos.write(buffer, 0, read);
+            }
+            byte[] bytes = bos.toByteArray();
+            if (bytes.length == 0) {
+                return null;
+            }
+            String mimeType = detectImageMimeType(bytes);
+            return "data:" + mimeType + ";base64," + Base64.getEncoder().encodeToString(bytes);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @NonNull
+    private String detectImageMimeType(@NonNull byte[] bytes) {
+        if (bytes.length >= 8
+                && bytes[0] == (byte) 0x89
+                && bytes[1] == 0x50
+                && bytes[2] == 0x4E
+                && bytes[3] == 0x47) {
+            return "image/png";
+        }
+        if (bytes.length >= 3
+                && bytes[0] == (byte) 0xFF
+                && bytes[1] == (byte) 0xD8
+                && bytes[2] == (byte) 0xFF) {
+            return "image/jpeg";
+        }
+        if (bytes.length >= 6 && bytes[0] == 'G' && bytes[1] == 'I' && bytes[2] == 'F') {
+            return "image/gif";
+        }
+        if (bytes.length >= 12
+                && bytes[0] == 'R'
+                && bytes[1] == 'I'
+                && bytes[2] == 'F'
+                && bytes[3] == 'F'
+                && bytes[8] == 'W'
+                && bytes[9] == 'E'
+                && bytes[10] == 'B'
+                && bytes[11] == 'P') {
+            return "image/webp";
+        }
+        return "application/octet-stream";
+    }
+
+    private long parseLeadingGid(@NonNull String dirname) {
+        int dash = dirname.indexOf('-');
+        String prefix = dash > 0 ? dirname.substring(0, dash) : dirname;
+        if (prefix.isEmpty()) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(prefix);
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private boolean matchesFilters(@Nullable BrowseMetadata metadata,
+                                   @Nullable String labelFilter,
+                                   @NonNull List<String> tagFilters,
+                                   @Nullable String searchFilter) {
+        boolean hasFilter = labelFilter != null || !tagFilters.isEmpty() || searchFilter != null;
+        if (!hasFilter) {
+            return true;
+        }
+        if (metadata == null) {
+            return false;
+        }
+
+        if (labelFilter != null && !BrowseFilterUtils.matchesLabel(metadata.labels, labelFilter)) {
+            return false;
+        }
+        if (!tagFilters.isEmpty() && !BrowseFilterUtils.matchesTags(metadata.tags, tagFilters)) {
+            return false;
+        }
+        return searchFilter == null || matchesSearch(metadata, searchFilter);
+    }
+
+    private boolean matchesSearch(@NonNull BrowseMetadata metadata, @NonNull String searchFilter) {
+        return BrowseFilterUtils.matchesSearch(metadata.title, metadata.labels, metadata.tags, searchFilter);
+    }
+
+    private void serveFile(@NonNull OutputStream os, @NonNull String encodedPath) throws IOException {
+        UniFile target = PathValidator.resolveRelativePath(root, encodedPath);
+        if (target == null || !target.exists() || !target.isFile()) {
+            ServerLog.e("Rejected file path: " + encodedPath);
+            writeJson(os, 403, jsonError("forbidden", "Invalid file path"));
+            return;
+        }
+
+        String name = target.getName() == null ? "file" : target.getName();
+        String type = ContentTypeUtils.fromName(name);
+        long length = Math.max(0, target.length());
+
+        writeStatusAndHeaders(os, 200, type, length);
+        try (InputStream in = target.openInputStream()) {
+            byte[] buffer = new byte[16 * 1024];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                os.write(buffer, 0, read);
+            }
+        }
+    }
+
+    private void writeJson(@NonNull OutputStream os, int code, @NonNull JSONObject object) throws IOException {
+        writeBytes(os, code, "application/json; charset=utf-8",
+                object.toJSONString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void writeText(@NonNull OutputStream os, int code, @NonNull String contentType,
+            @NonNull String body) throws IOException {
+        writeBytes(os, code, contentType, body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void writeBytes(@NonNull OutputStream os, int code, @NonNull String contentType,
+            @NonNull byte[] body) throws IOException {
+        writeStatusAndHeaders(os, code, contentType, body.length);
+        os.write(body);
+    }
+
+    private void writeStatusAndHeaders(@NonNull OutputStream os, int code,
+            @NonNull String contentType, long contentLength) throws IOException {
+        StringBuilder headers = new StringBuilder();
+        headers.append("HTTP/1.1 ").append(code).append(' ').append(reason(code)).append("\r\n")
+                .append("Content-Type: ").append(contentType).append("\r\n")
+                .append("Content-Length: ").append(contentLength).append("\r\n")
+                .append("Access-Control-Allow-Origin: *\r\n")
+                .append("Connection: close\r\n")
+                .append("\r\n");
+        os.write(headers.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @NonNull
+    private byte[] readAsset(@NonNull String path) throws IOException {
+        try (InputStream is = context.getAssets().open(path);
+             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8 * 1024];
+            int read;
+            while ((read = is.read(buffer)) >= 0) {
+                bos.write(buffer, 0, read);
+            }
+            return bos.toByteArray();
+        }
+    }
+
+    @NonNull
+    private JSONObject jsonError(@NonNull String code, @NonNull String message) {
+        JSONObject object = new JSONObject();
+        object.put("error", code);
+        object.put("message", message);
+        return object;
+    }
+
+    @NonNull
+    private String parentPath(@NonNull String path) {
+        if (path.isEmpty()) {
+            return "";
+        }
+        int index = path.lastIndexOf('/');
+        if (index < 0) {
+            return "";
+        }
+        return path.substring(0, index);
+    }
+
+    @NonNull
+    private String reason(int code) {
+        return switch (code) {
+            case 200 -> "OK";
+            case 403 -> "Forbidden";
+            case 404 -> "Not Found";
+            case 405 -> "Method Not Allowed";
+            default -> "Error";
+        };
+    }
+
+    private static final class HttpRequest {
+        String method;
+        String path;
+        Map<String, String> query;
+    }
+
+    private static final class Pagination {
+        final boolean enabled;
+        final int page;
+        final int limit;
+
+        private Pagination(boolean enabled, int page, int limit) {
+            this.enabled = enabled;
+            this.page = page;
+            this.limit = limit;
+        }
+
+        static Pagination disabled() {
+            return new Pagination(false, DEFAULT_PAGE, DEFAULT_LIMIT);
+        }
+
+        static Pagination enabled(int page, int limit) {
+            return new Pagination(true, page, limit);
+        }
+    }
+
+    private static final class BrowseItem {
+        long gid;
+        String name;
+        String path;
+        boolean directory;
+        long size;
+        long modified;
+        String mimeType;
+        boolean image;
+        String url;
+        BrowseMetadata metadata;
+    }
+
+    private static final class BrowseMetadata {
+        String title;
+        Float rating;
+        Integer pageCount;
+        JSONObject readProgress;
+        List<String> labels = Collections.emptyList();
+        List<String> tags = Collections.emptyList();
+        String uploader = "-";
+        String category = "-";
+        String thumbnailUrl;
+    }
+
+    private static final class MetadataContext {
+        final Map<Long, DownloadInfo> byGid;
+        final Map<String, DownloadInfo> byDirname;
+        final Map<Long, List<String>> tagsByGid;
+
+        MetadataContext(@NonNull Map<Long, DownloadInfo> byGid,
+                        @NonNull Map<String, DownloadInfo> byDirname,
+                        @NonNull Map<Long, List<String>> tagsByGid) {
+            this.byGid = byGid;
+            this.byDirname = byDirname;
+            this.tagsByGid = tagsByGid;
+        }
+
+        static MetadataContext empty() {
+            return new MetadataContext(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+        }
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/api/package-info.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/api/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * HTTP endpoint layer for LAN server mode.
+ *
+ * <p>This package contains the low-level request parser and endpoint handlers for
+ * <code>/</code>, <code>/api/browse</code>, and <code>/files/*</code>.</p>
+ */
+package com.hippo.ehviewer.server.api;

--- a/app/src/main/java/com/hippo/ehviewer/server/model/ServerState.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/model/ServerState.java
@@ -1,0 +1,24 @@
+package com.hippo.ehviewer.server.model;
+
+import androidx.annotation.NonNull;
+
+import com.alibaba.fastjson.JSONArray;
+
+public final class ServerState {
+    public final boolean running;
+    public final int configuredPort;
+    public final int boundPort;
+    @NonNull
+    public final JSONArray addresses;
+    @NonNull
+    public final String lastError;
+
+    public ServerState(boolean running, int configuredPort, int boundPort,
+            @NonNull JSONArray addresses, @NonNull String lastError) {
+        this.running = running;
+        this.configuredPort = configuredPort;
+        this.boundPort = boundPort;
+        this.addresses = addresses;
+        this.lastError = lastError;
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/model/package-info.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Lightweight data models used by LAN server mode.
+ */
+package com.hippo.ehviewer.server.model;

--- a/app/src/main/java/com/hippo/ehviewer/server/service/LanServerService.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/service/LanServerService.java
@@ -1,0 +1,155 @@
+package com.hippo.ehviewer.server.service;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
+import com.hippo.ehviewer.R;
+import com.hippo.ehviewer.server.model.ServerState;
+import com.hippo.ehviewer.server.util.ServerLog;
+import com.hippo.ehviewer.server.util.ServerSettings;
+import com.hippo.ehviewer.ui.SettingsActivity;
+
+public class LanServerService extends Service {
+
+    public static final String ACTION_START = "com.hippo.ehviewer.server.START";
+    public static final String ACTION_STOP = "com.hippo.ehviewer.server.STOP";
+    public static final String ACTION_RESTART = "com.hippo.ehviewer.server.RESTART";
+
+    public static final String CHANNEL_ID = "ehviewer_lan_server";
+    private static final int NOTIFY_ID = 4112;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createChannel();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        String action = intent != null ? intent.getAction() : ACTION_START;
+        if (ACTION_STOP.equals(action)) {
+            stopServerAndSelf();
+            return START_NOT_STICKY;
+        }
+
+        if (ACTION_RESTART.equals(action)) {
+            ServerController.get(this).restart();
+        } else {
+            ServerController.get(this).start();
+        }
+
+        startForeground(NOTIFY_ID, buildNotification());
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        ServerController.get(this).stop();
+        super.onDestroy();
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    public static void startServer(@NonNull Context context) {
+        Intent intent = new Intent(context, LanServerService.class);
+        intent.setAction(ACTION_START);
+        ContextCompat.startForegroundService(context, intent);
+    }
+
+    public static void stopServer(@NonNull Context context) {
+        Intent intent = new Intent(context, LanServerService.class);
+        intent.setAction(ACTION_STOP);
+        context.startService(intent);
+    }
+
+    public static void restartServer(@NonNull Context context) {
+        Intent intent = new Intent(context, LanServerService.class);
+        intent.setAction(ACTION_RESTART);
+        ContextCompat.startForegroundService(context, intent);
+    }
+
+    private void stopServerAndSelf() {
+        ServerSettings.setEnabled(false);
+        ServerController.get(this).stop();
+        stopForeground(STOP_FOREGROUND_REMOVE);
+        stopSelf();
+    }
+
+    private void createChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager == null) {
+            return;
+        }
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.server_notification_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+        );
+        channel.setDescription(getString(R.string.server_notification_channel_desc));
+        manager.createNotificationChannel(channel);
+    }
+
+    private Notification buildNotification() {
+        ServerState state = ServerController.get(this).getState();
+
+        Intent settingsIntent = new Intent(this, SettingsActivity.class);
+        PendingIntent settingsPending = PendingIntent.getActivity(
+                this,
+                1001,
+                settingsIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+
+        Intent stopIntent = new Intent(this, LanServerService.class);
+        stopIntent.setAction(ACTION_STOP);
+        PendingIntent stopPending = PendingIntent.getService(
+                this,
+                1002,
+                stopIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+
+        String title = getString(R.string.server_notification_title);
+        String text;
+        if (state.running && state.boundPort > 0) {
+            text = getString(R.string.server_notification_running, state.boundPort);
+        } else {
+            text = getString(R.string.server_notification_stopped);
+            if (!state.lastError.isEmpty()) {
+                ServerLog.e("Service state error: " + state.lastError);
+            }
+        }
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.v_download_dark_x24)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setContentIntent(settingsPending)
+                .addAction(new NotificationCompat.Action(
+                        R.drawable.v_clear_all_dark_x24,
+                        getString(R.string.server_notification_stop_action),
+                        stopPending))
+                .build();
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/service/ServerController.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/service/ServerController.java
@@ -1,0 +1,139 @@
+package com.hippo.ehviewer.server.service;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.alibaba.fastjson.JSONArray;
+import com.hippo.ehviewer.Settings;
+import com.hippo.ehviewer.server.api.SimpleHttpServer;
+import com.hippo.ehviewer.server.model.ServerState;
+import com.hippo.ehviewer.server.util.NetworkUtils;
+import com.hippo.ehviewer.server.util.ServerLog;
+import com.hippo.ehviewer.server.util.ServerSettings;
+import com.hippo.unifile.UniFile;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public final class ServerController {
+
+    private static volatile ServerController sInstance;
+
+    @NonNull
+    private final Context context;
+
+    private SimpleHttpServer server;
+    private boolean running;
+    private int configuredPort;
+    private int boundPort;
+    @NonNull
+    private String lastError = "";
+
+    private ServerController(@NonNull Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @NonNull
+    public static ServerController get(@NonNull Context context) {
+        if (sInstance == null) {
+            synchronized (ServerController.class) {
+                if (sInstance == null) {
+                    sInstance = new ServerController(context);
+                }
+            }
+        }
+        return sInstance;
+    }
+
+    public synchronized boolean start() {
+        if (running) {
+            return true;
+        }
+
+        UniFile root = Settings.getDownloadLocation();
+        if (root == null || !root.exists() || !root.isDirectory()) {
+            lastError = "Download location is unavailable";
+            ServerLog.e(lastError);
+            return false;
+        }
+
+        configuredPort = ServerSettings.getConfiguredPort();
+        int candidate = configuredPort;
+        int picked = -1;
+        int maxAttempts = 20;
+
+        for (int i = 0; i < maxAttempts; i++) {
+            if (isPortAvailable(candidate)) {
+                picked = candidate;
+                break;
+            }
+            candidate++;
+        }
+
+        if (picked < 1) {
+            lastError = "No available port found near " + configuredPort;
+            ServerLog.e(lastError);
+            return false;
+        }
+
+        try {
+            server = new SimpleHttpServer(context, root, picked);
+            server.start();
+            running = true;
+            boundPort = picked;
+            ServerSettings.setBoundPort(picked);
+            lastError = "";
+            ServerLog.i("LAN server started on port " + picked);
+            if (picked != configuredPort) {
+                ServerLog.e("Configured port " + configuredPort + " is occupied, fallback to " + picked);
+            }
+            return true;
+        } catch (IOException e) {
+            lastError = "Failed to start server: " + e.getMessage();
+            ServerLog.e(lastError);
+            running = false;
+            boundPort = 0;
+            ServerSettings.setBoundPort(0);
+            return false;
+        }
+    }
+
+    public synchronized void stop() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+        running = false;
+        boundPort = 0;
+        ServerSettings.setBoundPort(0);
+        ServerLog.i("LAN server stopped");
+    }
+
+    public synchronized boolean restart() {
+        stop();
+        return start();
+    }
+
+    @NonNull
+    public synchronized ServerState getState() {
+        JSONArray addresses = NetworkUtils.getLanIpv4AddressesJsonArray();
+        return new ServerState(running, ServerSettings.getConfiguredPort(), boundPort, addresses, lastError);
+    }
+
+    public synchronized boolean isRunning() {
+        return running;
+    }
+
+    private boolean isPortAvailable(int port) {
+        if (port < 1 || port > 65535) {
+            return false;
+        }
+        try (ServerSocket socket = new ServerSocket(port)) {
+            socket.setReuseAddress(true);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/service/package-info.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/service/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Lifecycle and foreground-service integration for LAN server mode.
+ *
+ * <p>This package owns startup/shutdown behavior, notification handling,
+ * and auto-restart hooks when server mode is enabled.</p>
+ */
+package com.hippo.ehviewer.server.service;

--- a/app/src/main/java/com/hippo/ehviewer/server/util/ContentTypeUtils.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/util/ContentTypeUtils.java
@@ -1,0 +1,24 @@
+package com.hippo.ehviewer.server.util;
+
+import androidx.annotation.NonNull;
+
+import java.net.URLConnection;
+
+public final class ContentTypeUtils {
+
+    private ContentTypeUtils() {
+    }
+
+    @NonNull
+    public static String fromName(@NonNull String name) {
+        String type = URLConnection.guessContentTypeFromName(name);
+        if (type == null || type.isEmpty()) {
+            return "application/octet-stream";
+        }
+        return type;
+    }
+
+    public static boolean isImage(@NonNull String mimeType) {
+        return mimeType.startsWith("image/");
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/util/NetworkUtils.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/util/NetworkUtils.java
@@ -1,0 +1,85 @@
+package com.hippo.ehviewer.server.util;
+
+import androidx.annotation.NonNull;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+public final class NetworkUtils {
+
+    private NetworkUtils() {
+    }
+
+    @NonNull
+    public static List<JSONObject> getLanIpv4Addresses() {
+        ArrayList<JSONObject> results = new ArrayList<>();
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces == null) {
+                return results;
+            }
+            for (NetworkInterface nif : Collections.list(interfaces)) {
+                if (!nif.isUp() || nif.isLoopback() || nif.isVirtual()) {
+                    continue;
+                }
+                String label = interfaceLabel(nif.getName());
+                for (InetAddress address : Collections.list(nif.getInetAddresses())) {
+                    if (!(address instanceof Inet4Address) || address.isLoopbackAddress()) {
+                        continue;
+                    }
+                    String host = address.getHostAddress();
+                    if (host == null || host.startsWith("169.254.")) {
+                        continue;
+                    }
+                    JSONObject row = new JSONObject();
+                    row.put("interface", nif.getName());
+                    row.put("label", label);
+                    row.put("address", host);
+                    results.add(row);
+                }
+            }
+        } catch (Throwable e) {
+            ServerLog.e("Network interface scan failed: " + e.getMessage());
+        }
+        return results;
+    }
+
+    @NonNull
+    public static JSONArray getLanIpv4AddressesJsonArray() {
+        JSONArray array = new JSONArray();
+        List<JSONObject> list = getLanIpv4Addresses();
+        for (JSONObject item : list) {
+            array.add(item);
+        }
+        return array;
+    }
+
+    @NonNull
+    private static String interfaceLabel(@NonNull String name) {
+        String lower = name.toLowerCase();
+        if (lower.startsWith("wlan") || lower.contains("wifi")) {
+            return "Wi-Fi";
+        }
+        if (lower.startsWith("rmnet") || lower.startsWith("ccmni") || lower.contains("mobile")) {
+            return "Mobile";
+        }
+        if (lower.startsWith("usb") || lower.contains("rndis")) {
+            return "USB";
+        }
+        if (lower.startsWith("eth")) {
+            return "Ethernet";
+        }
+        if (lower.startsWith("ap")) {
+            return "Tethering";
+        }
+        return name;
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/util/PathValidator.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/util/PathValidator.java
@@ -1,0 +1,103 @@
+package com.hippo.ehviewer.server.util;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.hippo.unifile.UniFile;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public final class PathValidator {
+
+    private PathValidator() {
+    }
+
+    @Nullable
+    public static UniFile resolveRelativePath(@NonNull UniFile root, @Nullable String requestPath) {
+        if (requestPath == null || requestPath.isEmpty() || "/".equals(requestPath)) {
+            return root;
+        }
+
+        String path = normalizePath(requestPath);
+        if (path.isEmpty()) {
+            return root;
+        }
+
+        UniFile current = root;
+        String[] segments = path.split("/");
+        for (String rawSegment : segments) {
+            if (rawSegment.isEmpty()) {
+                continue;
+            }
+            String segment = decode(rawSegment);
+            if (!isSafeSegment(segment)) {
+                return null;
+            }
+            current = current.findFile(segment);
+            if (current == null) {
+                return null;
+            }
+        }
+
+        return current;
+    }
+
+    @NonNull
+    public static String encodePath(@NonNull String relativePath) {
+        String[] segments = normalizePath(relativePath).split("/");
+        StringBuilder sb = new StringBuilder();
+        for (String segment : segments) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            if (!sb.isEmpty()) {
+                sb.append('/');
+            }
+            sb.append(encode(segment));
+        }
+        return sb.toString();
+    }
+
+    @NonNull
+    public static String normalizePath(@Nullable String path) {
+        if (path == null) {
+            return "";
+        }
+        String trimmed = path.replace('\\', '/').trim();
+        while (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1);
+        }
+        return trimmed;
+    }
+
+    private static boolean isSafeSegment(@Nullable String segment) {
+        if (segment == null || segment.isEmpty()) {
+            return false;
+        }
+        if (".".equals(segment) || "..".equals(segment)) {
+            return false;
+        }
+        return !(segment.contains("/") || segment.contains("\\"));
+    }
+
+    @NonNull
+    private static String decode(@NonNull String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            return value;
+        }
+    }
+
+    @NonNull
+    private static String encode(@NonNull String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name()).replace("+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            return value;
+        }
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/util/ServerLog.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/util/ServerLog.java
@@ -1,0 +1,95 @@
+package com.hippo.ehviewer.server.util;
+
+import androidx.annotation.NonNull;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+public final class ServerLog {
+
+    public enum Level {
+        DEBUG,
+        INFO,
+        ERROR
+    }
+
+    public static final class Entry {
+        public final long timestamp;
+        @NonNull
+        public final Level level;
+        @NonNull
+        public final String message;
+
+        Entry(long timestamp, @NonNull Level level, @NonNull String message) {
+            this.timestamp = timestamp;
+            this.level = level;
+            this.message = message;
+        }
+
+        @NonNull
+        public String format() {
+            String time = new SimpleDateFormat("HH:mm:ss", Locale.US).format(new Date(timestamp));
+            return time + " [" + level.name() + "] " + message;
+        }
+    }
+
+    private static final int MAX_ENTRIES = 500;
+    private static final ArrayList<Entry> ENTRIES = new ArrayList<>();
+
+    private ServerLog() {
+    }
+
+    public static synchronized void clear() {
+        ENTRIES.clear();
+    }
+
+    public static synchronized void d(@NonNull String message) {
+        log(Level.DEBUG, message);
+    }
+
+    public static synchronized void i(@NonNull String message) {
+        log(Level.INFO, message);
+    }
+
+    public static synchronized void e(@NonNull String message) {
+        log(Level.ERROR, message);
+    }
+
+    public static synchronized void log(@NonNull Level level, @NonNull String message) {
+        Level current = ServerSettings.getLogLevel();
+        if (!shouldRecord(level, current)) {
+            return;
+        }
+        ENTRIES.add(new Entry(System.currentTimeMillis(), level, message));
+        if (ENTRIES.size() > MAX_ENTRIES) {
+            ENTRIES.remove(0);
+        }
+    }
+
+    @NonNull
+    public static synchronized List<Entry> snapshot() {
+        return new ArrayList<>(ENTRIES);
+    }
+
+    @NonNull
+    public static synchronized String dumpText() {
+        StringBuilder sb = new StringBuilder();
+        for (Entry entry : ENTRIES) {
+            sb.append(entry.format()).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static boolean shouldRecord(@NonNull Level incoming, @NonNull Level current) {
+        if (current == Level.DEBUG) {
+            return true;
+        }
+        if (current == Level.INFO) {
+            return incoming == Level.INFO || incoming == Level.ERROR;
+        }
+        return incoming == Level.ERROR;
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/util/ServerSettings.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/util/ServerSettings.java
@@ -1,0 +1,55 @@
+package com.hippo.ehviewer.server.util;
+
+import androidx.annotation.NonNull;
+
+import com.hippo.ehviewer.Settings;
+
+public final class ServerSettings {
+
+    private static final int DEFAULT_PORT = 8080;
+
+    private ServerSettings() {
+    }
+
+    public static boolean isEnabled() {
+        return Settings.getServerEnabled();
+    }
+
+    public static void setEnabled(boolean enabled) {
+        Settings.putServerEnabled(enabled);
+    }
+
+    public static int getConfiguredPort() {
+        int port = Settings.getServerPort();
+        if (port < 1 || port > 65535) {
+            return DEFAULT_PORT;
+        }
+        return port;
+    }
+
+    public static void setConfiguredPort(int port) {
+        Settings.putServerPort(port);
+    }
+
+    public static int getBoundPort() {
+        return Settings.getServerBoundPort();
+    }
+
+    public static void setBoundPort(int port) {
+        Settings.putServerBoundPort(port);
+    }
+
+    @NonNull
+    public static ServerLog.Level getLogLevel() {
+        String raw = Settings.getServerLogLevel();
+        try {
+            return ServerLog.Level.valueOf(raw);
+        } catch (Throwable ignored) {
+            return ServerLog.Level.INFO;
+        }
+    }
+
+    public static void setLogLevel(@NonNull String level) {
+        Settings.putServerLogLevel(level);
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/server/util/package-info.java
+++ b/app/src/main/java/com/hippo/ehviewer/server/util/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Utilities shared by LAN server mode.
+ *
+ * <p>Includes path validation, LAN IP discovery, content-type detection,
+ * runtime logging, and server setting helpers.</p>
+ */
+package com.hippo.ehviewer.server.util;

--- a/app/src/main/java/com/hippo/ehviewer/ui/fragment/ServerSettingsFragment.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/fragment/ServerSettingsFragment.java
@@ -1,0 +1,176 @@
+package com.hippo.ehviewer.ui.fragment;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.preference.Preference;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.hippo.ehviewer.R;
+import com.hippo.ehviewer.server.model.ServerState;
+import com.hippo.ehviewer.server.service.LanServerService;
+import com.hippo.ehviewer.server.service.ServerController;
+import com.hippo.ehviewer.server.util.ServerSettings;
+import com.hippo.ehviewer.ui.server.ServerLogActivity;
+
+public class ServerSettingsFragment extends BasePreferenceFragmentCompat implements
+        Preference.OnPreferenceChangeListener,
+        Preference.OnPreferenceClickListener {
+
+    private static final String KEY_STATUS = "server_status";
+    private static final String KEY_ADDRESSES = "server_addresses";
+    private static final String KEY_LOGS = "server_open_logs";
+
+    private Preference statusPreference;
+    private Preference addressesPreference;
+    private Preference portPreference;
+
+    @Override
+    public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
+        addPreferencesFromResource(R.xml.server_settings);
+
+        Preference enabled = findPreference(com.hippo.ehviewer.Settings.KEY_SERVER_ENABLED);
+        statusPreference = findPreference(KEY_STATUS);
+        addressesPreference = findPreference(KEY_ADDRESSES);
+        portPreference = findPreference(com.hippo.ehviewer.Settings.KEY_SERVER_PORT);
+        Preference logLevel = findPreference(com.hippo.ehviewer.Settings.KEY_SERVER_LOG_LEVEL);
+        Preference openLogs = findPreference(KEY_LOGS);
+
+        if (enabled != null) {
+            enabled.setOnPreferenceChangeListener(this);
+        }
+        if (portPreference != null) {
+            portPreference.setOnPreferenceChangeListener(this);
+        }
+        if (logLevel != null) {
+            logLevel.setOnPreferenceChangeListener(this);
+        }
+        if (openLogs != null) {
+            openLogs.setOnPreferenceClickListener(this);
+        }
+
+        refreshState();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        refreshState();
+    }
+
+    private void refreshState() {
+        if (getContext() == null) {
+            return;
+        }
+        ServerState state = ServerController.get(getContext()).getState();
+
+        if (statusPreference != null) {
+            if (state.running) {
+                statusPreference.setSummary(getString(R.string.server_status_running, state.boundPort));
+            } else if (!TextUtils.isEmpty(state.lastError)) {
+                statusPreference.setSummary(getString(R.string.server_status_error, state.lastError));
+            } else {
+                statusPreference.setSummary(R.string.server_status_stopped);
+            }
+        }
+
+        if (portPreference != null) {
+            int configured = ServerSettings.getConfiguredPort();
+            if (state.running && state.boundPort > 0 && state.boundPort != configured) {
+                portPreference.setSummary(getString(R.string.server_port_summary_fallback, configured, state.boundPort));
+            } else {
+                portPreference.setSummary(getString(R.string.server_port_summary, configured));
+            }
+        }
+
+        if (addressesPreference != null) {
+            addressesPreference.setSummary(formatAddresses(state.addresses, state.boundPort));
+            addressesPreference.setEnabled(state.running);
+        }
+    }
+
+    private CharSequence formatAddresses(JSONArray addresses, int port) {
+        if (addresses == null || addresses.isEmpty() || port <= 0) {
+            return getString(R.string.server_no_address);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < addresses.size(); i++) {
+            JSONObject row = addresses.getJSONObject(i);
+            if (row == null) {
+                continue;
+            }
+            String label = row.getString("label");
+            String address = row.getString("address");
+            if (TextUtils.isEmpty(address)) {
+                continue;
+            }
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(label).append(": http://").append(address).append(':').append(port);
+        }
+        if (sb.length() == 0) {
+            return getString(R.string.server_no_address);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        String key = preference.getKey();
+        if (com.hippo.ehviewer.Settings.KEY_SERVER_ENABLED.equals(key)) {
+            boolean enable = Boolean.TRUE.equals(newValue);
+            ServerSettings.setEnabled(enable);
+            if (getContext() != null) {
+                if (enable) {
+                    LanServerService.startServer(requireContext());
+                } else {
+                    LanServerService.stopServer(requireContext());
+                }
+            }
+            refreshState();
+            return true;
+        }
+
+        if (com.hippo.ehviewer.Settings.KEY_SERVER_PORT.equals(key)) {
+            int port;
+            try {
+                port = Integer.parseInt(String.valueOf(newValue));
+            } catch (Throwable e) {
+                Toast.makeText(getContext(), R.string.server_port_invalid, Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            if (port < 1 || port > 65535) {
+                Toast.makeText(getContext(), R.string.server_port_invalid, Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            ServerSettings.setConfiguredPort(port);
+            if (ServerSettings.isEnabled() && getContext() != null) {
+                LanServerService.restartServer(requireContext());
+            }
+            refreshState();
+            return true;
+        }
+
+        if (com.hippo.ehviewer.Settings.KEY_SERVER_LOG_LEVEL.equals(key)) {
+            String level = String.valueOf(newValue);
+            ServerSettings.setLogLevel(level);
+            return true;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+        if (KEY_LOGS.equals(preference.getKey()) && getContext() != null) {
+            startActivity(new Intent(getContext(), ServerLogActivity.class));
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/ui/server/ServerLogActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/server/ServerLogActivity.java
@@ -1,0 +1,32 @@
+package com.hippo.ehviewer.ui.server;
+
+import android.os.Bundle;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
+import com.hippo.ehviewer.R;
+import com.hippo.ehviewer.server.util.ServerLog;
+import com.hippo.ehviewer.ui.ToolbarActivity;
+
+public class ServerLogActivity extends ToolbarActivity {
+
+    private TextView content;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_server_log);
+        setNavigationIcon(R.drawable.v_arrow_left_dark_x24);
+        content = findViewById(R.id.server_log_content);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (content != null) {
+            String dump = ServerLog.dumpText();
+            content.setText(dump.isEmpty() ? getString(R.string.server_log_empty) : dump);
+        }
+    }
+}

--- a/app/src/main/java/com/hippo/ehviewer/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/splash/SplashActivity.kt
@@ -9,6 +9,7 @@ import com.hippo.ehviewer.client.EhClient
 import com.hippo.ehviewer.client.EhRequest
 import com.hippo.ehviewer.client.EhUrl
 import com.hippo.ehviewer.client.data.EhNewsDetail
+import com.hippo.ehviewer.server.service.LanServerService
 import com.hippo.ehviewer.ui.EhActivity
 import com.hippo.ehviewer.ui.MainActivity
 //import com.hippo.ehviewer.ui.dialog.EhDistributeListener
@@ -35,6 +36,9 @@ class SplashActivity : EhActivity() {
 //        Distribute.setEnabled(!Settings.getCloseAutoUpdate())
         super.onCreate(savedInstanceState)
         setContentView(R.layout.splash_layout)
+        if (Settings.getServerEnabled()) {
+            LanServerService.startServer(this)
+        }
         Thread(Runnable {
             //耗时任务，比如加载网络数据
             runOnUiThread(Runnable {

--- a/app/src/main/res/layout/activity_server_log.xml
+++ b/app/src/main/res/layout/activity_server_log.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/server_log_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:typeface="monospace" />
+
+</ScrollView>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -203,6 +203,18 @@
         <item>17</item>
     </string-array>
 
+    <string-array name="server_log_level_entries" translatable="false">
+        <item>INFO</item>
+        <item>DEBUG</item>
+        <item>ERROR</item>
+    </string-array>
+
+    <string-array name="server_log_level_values" translatable="false">
+        <item>INFO</item>
+        <item>DEBUG</item>
+        <item>ERROR</item>
+    </string-array>
+
     <string-array name="image_resolution_entries" translatable="false">
         <item>@string/settings_download_image_resolution_auto</item>
         <item>780x</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1074,4 +1074,33 @@
     <string name="imported_archive_category">Local Import</string>
     <!-- TagSelectActivity -->
     <string name="tag_search_entrance">Tag Selector</string>
+
+    <!-- LAN server mode -->
+    <string name="settings_server">Server</string>
+    <string name="server_enabled_title">Enable LAN server mode</string>
+    <string name="server_enabled_summary">Serve the download library to browsers on your local network</string>
+    <string name="server_status_title">Server status</string>
+    <string name="server_status_stopped">Server stopped</string>
+    <string name="server_status_running">Server running on port %d</string>
+    <string name="server_status_error">Failed: %s</string>
+    <string name="server_address_title">LAN addresses</string>
+    <string name="server_no_address">No active LAN address</string>
+    <string name="server_port_title">Server port</string>
+    <string name="server_port_hint">Set preferred port (1-65535)</string>
+    <string name="server_port_summary">Configured port: %d</string>
+    <string name="server_port_summary_fallback">Configured %1$d, currently bound %2$d</string>
+    <string name="server_port_invalid">Please enter a port between 1 and 65535</string>
+    <string name="server_log_level_title">Log level</string>
+    <string name="server_open_logs_title">Open server logs</string>
+    <string name="server_open_logs_summary">View current-session server logs</string>
+    <string name="server_log_empty">No logs in this session</string>
+    <string name="server_help_title">Read-only mode</string>
+    <string name="server_help_summary">This server only allows browsing and viewing files under the configured download directory. Modify/delete controls are intentionally unavailable.</string>
+
+    <string name="server_notification_channel_name">LAN server</string>
+    <string name="server_notification_channel_desc">Foreground notification for EhViewer LAN server mode</string>
+    <string name="server_notification_title">EhViewer LAN server</string>
+    <string name="server_notification_running">Running on port %d</string>
+    <string name="server_notification_stopped">Stopped</string>
+    <string name="server_notification_stop_action">Stop</string>
 </resources>

--- a/app/src/main/res/xml/server_settings.xml
+++ b/app/src/main/res/xml/server_settings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.hippo.preference.SwitchPreference
+        android:defaultValue="false"
+        android:key="server_enabled"
+        android:summary="@string/server_enabled_summary"
+        android:title="@string/server_enabled_title" />
+
+    <Preference
+        android:key="server_status"
+        android:summary="@string/server_status_stopped"
+        android:title="@string/server_status_title"
+        app:allowDividerAbove="true"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="server_addresses"
+        android:summary="@string/server_no_address"
+        android:title="@string/server_address_title"
+        app:iconSpaceReserved="false" />
+
+    <androidx.preference.EditTextPreference
+        android:defaultValue="8080"
+        android:key="server_port"
+        android:summary="@string/server_port_hint"
+        android:title="@string/server_port_title"
+        app:allowDividerAbove="true"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="false" />
+
+    <com.hippo.preference.ListPreference
+        android:defaultValue="INFO"
+        android:key="server_log_level"
+        android:title="@string/server_log_level_title"
+        app:entries="@array/server_log_level_entries"
+        app:entryValues="@array/server_log_level_values"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="server_open_logs"
+        android:summary="@string/server_open_logs_summary"
+        android:title="@string/server_open_logs_title"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:summary="@string/server_help_summary"
+        android:title="@string/server_help_title"
+        app:allowDividerAbove="true"
+        app:selectable="false" />
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/settings_headers.xml
+++ b/app/src/main/res/xml/settings_headers.xml
@@ -36,6 +36,12 @@
         app:fragment="com.hippo.ehviewer.ui.fragment.DownloadFragment" />
 
     <com.hippo.ehviewer.ui.fragment.BasePreference
+        android:icon="@drawable/v_folder_share_dark_x24"
+        android:title="@string/settings_server"
+        app:allowDividerAbove="true"
+        app:fragment="com.hippo.ehviewer.ui.fragment.ServerSettingsFragment" />
+
+    <com.hippo.ehviewer.ui.fragment.BasePreference
         android:icon="@drawable/v_sec_primary_x24"
         android:title="@string/settings_privacy"
         app:allowDividerAbove="true"

--- a/app/src/test/java/com/hippo/ehviewer/server/api/BrowseFilterUtilsTest.java
+++ b/app/src/test/java/com/hippo/ehviewer/server/api/BrowseFilterUtilsTest.java
@@ -1,0 +1,88 @@
+package com.hippo.ehviewer.server.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.hippo.ehviewer.dao.GalleryTags;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BrowseFilterUtilsTest {
+
+    @Test
+    public void normalizeFilterValue_emptyBecomesNull() {
+        assertNull(BrowseFilterUtils.normalizeFilterValue("   "));
+        assertEquals("Work", BrowseFilterUtils.normalizeFilterValue(" Work "));
+    }
+
+    @Test
+    public void parseTagFilters_trimsAndSkipsEmpty() {
+        List<String> tags = BrowseFilterUtils.parseTagFilters(" manga, doujin , ,female:big ");
+        assertEquals(Arrays.asList("manga", "doujin", "female:big"), tags);
+    }
+
+    @Test
+    public void matchesLabel_caseInsensitive() {
+        assertTrue(BrowseFilterUtils.matchesLabel(Arrays.asList("Work"), "work"));
+        assertFalse(BrowseFilterUtils.matchesLabel(Arrays.asList("Work"), "home"));
+    }
+
+    @Test
+    public void matchesLabel_defaultMatchesUnlabeled() {
+        // "Default" should match items with empty labels (unlabeled)
+        assertTrue(BrowseFilterUtils.matchesLabel(Collections.emptyList(), "Default"));
+        assertTrue(BrowseFilterUtils.matchesLabel(Collections.emptyList(), "default"));
+        // "Default" should NOT match items that have labels
+        assertFalse(BrowseFilterUtils.matchesLabel(Arrays.asList("Work"), "Default"));
+        assertFalse(BrowseFilterUtils.matchesLabel(Arrays.asList("Work"), "default"));
+    }
+
+    @Test
+    public void matchesTags_orLogicAndNamespaceSupport() {
+        List<String> tags = Arrays.asList("female:big_breasts", "language:english");
+        assertTrue(BrowseFilterUtils.matchesTags(tags, Arrays.asList("manga", "big_breasts")));
+        assertTrue(BrowseFilterUtils.matchesTags(tags, Arrays.asList("female:big")));
+        assertFalse(BrowseFilterUtils.matchesTags(tags, Arrays.asList("male:big")));
+    }
+
+    @Test
+    public void matchesSearch_checksTitleLabelsAndTags() {
+        assertTrue(BrowseFilterUtils.matchesSearch(
+                "Demon Hunter",
+                Arrays.asList("Work"),
+                Arrays.asList("genre:action"),
+                "demon"));
+
+        assertTrue(BrowseFilterUtils.matchesSearch(
+                "Other title",
+                Arrays.asList("Favorites"),
+                Arrays.asList("genre:action"),
+                "acti"));
+
+        assertFalse(BrowseFilterUtils.matchesSearch(
+                "Other title",
+                Arrays.asList("Favorites"),
+                Arrays.asList("genre:action"),
+                "romance"));
+    }
+
+    @Test
+    public void extractTags_collectsAllNamespaces() {
+        GalleryTags tags = new GalleryTags(1L);
+        tags.artist = "foo, bar";
+        tags.language = "english";
+        tags.female = "big_breasts";
+
+        List<String> result = BrowseFilterUtils.extractTags(tags);
+        assertTrue(result.contains("artist:foo"));
+        assertTrue(result.contains("artist:bar"));
+        assertTrue(result.contains("language:english"));
+        assertTrue(result.contains("female:big_breasts"));
+    }
+}


### PR DESCRIPTION
- Introduced an embedded HTTP server to allow browsing of downloaded manga/comics over LAN.
- Implemented server startup/shutdown functionality with network interface binding.
- Added a read-only HTML client for item browsing, including display modes, search/filter, and metadata.
- Implemented immersive reader overlay with slide animations, drag-follow swipe, tap zones, and keyboard navigation.
- Added adjacent image preloading for smoother page transitions in the web reader.
- Created a settings UI for enabling/disabling server mode, displaying local IP addresses, and configuring server port.
- Ensured security with path validation to prevent unauthorized access to files outside the download directory.
- Implemented logging for server activity with adjustable verbosity levels.
- Enhanced server API with rich metadata (thumbnails, title, rating, page count, read progress, labels, tags).
- Added BrowseFilterUtils for label/tag/keyword filtering with unit tests.
- Implemented default label handling for unlabeled items in server filtering.

I start the server on my android phone

<img width="836" height="512" alt="image" src="https://github.com/user-attachments/assets/d3bd9aae-c5e1-496e-b4c7-b5d50f9fd761" />

and I am able to browse my downloads on another ipad under the same LAN

<img width="1225" height="858" alt="image" src="https://github.com/user-attachments/assets/05820f80-04d8-4bad-a477-5f260fe7c81a" />
