### PR TITLE
fix: 恢复沉浸式系统栏并修复评论输入框避让

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/EhActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/EhActivity.java
@@ -46,6 +46,29 @@ public abstract class EhActivity extends AppCompatActivity {
         setTheme(getThemeResId(Settings.getTheme()));
         super.onCreate(savedInstanceState);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().getDecorView().setSystemUiVisibility(
+                    getWindow().getDecorView().getSystemUiVisibility()
+                            | android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                            | android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                            | android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            );
+            getWindow().setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+            getWindow().setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            int visibility = getWindow().getDecorView().getSystemUiVisibility();
+            if (Settings.getTheme() == Settings.THEME_LIGHT) {
+                visibility |= android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            } else {
+                visibility &= ~android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            }
+            getWindow().getDecorView().setSystemUiVisibility(visibility);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            getWindow().setNavigationBarContrastEnforced(false);
+        }
+
         ((EhApplication) getApplication()).registerActivity(this);
 
         if (Analytics.isEnabled()) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/MainActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/MainActivity.java
@@ -112,7 +112,6 @@ import com.hippo.util.GifHandler;
 import com.hippo.util.PermissionRequester;
 import com.hippo.widget.AvatarImageView;
 import com.hippo.lib.yorozuya.IOUtils;
-import com.hippo.lib.yorozuya.ResourcesUtils;
 import com.hippo.lib.yorozuya.SimpleHandler;
 import com.hippo.lib.yorozuya.ViewUtils;
 
@@ -406,8 +405,7 @@ public final class MainActivity extends StageActivity
 
         limitsCountView = (LimitsCountView) ViewUtils.$$(this, R.id.limits_count_view);
 
-        mDrawerLayout.setStatusBarColor(ResourcesUtils.getAttrColor(this, androidx.appcompat.R.attr.colorPrimaryDark));
-//        mDrawerLayout.setStatusBarColor(0);
+        mDrawerLayout.setStatusBarColor(0);
 
         if (mNavView != null) {
 //            if (Settings.isLogin()){

--- a/app/src/main/java/com/hippo/ehviewer/ui/SettingsActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/SettingsActivity.java
@@ -21,13 +21,19 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.view.MenuItem;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.hippo.ehviewer.R;
 import com.hippo.ehviewer.Settings;
@@ -70,12 +76,42 @@ public final class SettingsActivity extends EhActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
         setActionBarUpIndicator(DrawableManager.getVectorDrawable(this, R.drawable.v_arrow_left_dark_x24));
+        setupTransparentNavigationBar();
         if (savedInstanceState==null){
             getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.settings,new SettingsHeaders())
                     .commit();
         }
+    }
+
+    /**
+     * 让设置列表绘制到透明的系统导航栏之下，实现沉浸式效果。
+     * 列表加上等高的底部 padding 并关闭 clipToPadding，使内容可以滚动到导航栏之下。
+     */
+    private void setupTransparentNavigationBar() {
+        getSupportFragmentManager().registerFragmentLifecycleCallbacks(
+                new FragmentManager.FragmentLifecycleCallbacks() {
+                    @Override
+                    public void onFragmentViewCreated(@NonNull FragmentManager fm, @NonNull Fragment f,
+                            @NonNull View v, @Nullable Bundle savedInstanceState) {
+                        if (!(f instanceof PreferenceFragmentCompat)) {
+                            return;
+                        }
+                        RecyclerView list = ((PreferenceFragmentCompat) f).getListView();
+                        if (list == null) {
+                            return;
+                        }
+                        list.setClipToPadding(false);
+                        ViewCompat.setOnApplyWindowInsetsListener(list, (rv, insets) -> {
+                            int bottom = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+                            rv.setPadding(rv.getPaddingLeft(), rv.getPaddingTop(),
+                                    rv.getPaddingRight(), bottom);
+                            return insets;
+                        });
+                        ViewCompat.requestApplyInsets(list);
+                    }
+                }, true);
     }
 
     @Override

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryCommentsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryCommentsScene.java
@@ -298,10 +298,12 @@ public final class GalleryCommentsScene extends ToolbarScene
             return;
         }
         ViewCompat.setOnApplyWindowInsetsListener(mEditPanel, (v, insets) -> {
-            int imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            int bottom = Math.max(
+                    insets.getInsets(WindowInsetsCompat.Type.ime()).bottom,
+                    insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom);
             ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            if (lp.bottomMargin != imeBottom) {
-                lp.bottomMargin = imeBottom;
+            if (lp.bottomMargin != bottom) {
+                lp.bottomMargin = bottom;
                 v.setLayoutParams(lp);
             }
             return insets;

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/ToolbarScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/ToolbarScene.java
@@ -58,8 +58,28 @@ public abstract class ToolbarScene extends BaseScene {
         } else {
             mToolbar = toolbar;
             contentPanel.addView(contentView, 0);
+            applyStatusBarTopInset(toolbar);
             return view;
         }
+    }
+
+    /**
+     * The scene draws under the transparent status bar — {@code EhStageLayout} no longer reserves
+     * the top inset (so the gallery 瀑布流 can scroll under the bar). Grow the toolbar up into the
+     * status bar so its background fills the bar (status bar takes the toolbar color) while the
+     * title / menu stay centered below the bar.
+     */
+    private static void applyStatusBarTopInset(Toolbar toolbar) {
+        int resId = toolbar.getResources().getIdentifier("status_bar_height", "dimen", "android");
+        int statusBarHeight = resId > 0 ? toolbar.getResources().getDimensionPixelSize(resId) : 0;
+        if (statusBarHeight <= 0) {
+            return;
+        }
+        ViewGroup.LayoutParams lp = toolbar.getLayoutParams();
+        lp.height += statusBarHeight;
+        toolbar.setLayoutParams(lp);
+        toolbar.setPadding(toolbar.getPaddingLeft(), toolbar.getPaddingTop() + statusBarHeight,
+                toolbar.getPaddingRight(), toolbar.getPaddingBottom());
     }
 
     @Override

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/FavoritesScene.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/FavoritesScene.kt
@@ -266,6 +266,15 @@ class FavoritesScene : BaseScene(), EasyRecyclerView.OnItemClickListener,
         val resources = context!!.getResources()
         val paddingTopSB = resources.getDimensionPixelOffset(R.dimen.gallery_padding_top_search_bar)
 
+        // Height of the transparent status bar. The scene now draws under it, so push the
+        // floating search bar and the list's resting top down — the 瀑布流 still scrolls
+        // under the bar because the RecyclerView keeps clipToPadding=false.
+        var statusBarHeight = 0
+        val statusBarResId = resources.getIdentifier("status_bar_height", "dimen", "android")
+        if (statusBarResId > 0) {
+            statusBarHeight = resources.getDimensionPixelSize(statusBarResId)
+        }
+
         mHelper = FavoritesHelper()
         mHelper!!.setEmptyString(resources.getString(R.string.gallery_list_empty_hit))
         contentLayout.setHelper(mHelper)
@@ -281,17 +290,22 @@ class FavoritesScene : BaseScene(), EasyRecyclerView.OnItemClickListener,
         )
         mRecyclerView!!.setDrawSelectorOnTop(true)
         mRecyclerView!!.setClipToPadding(false)
+        mRecyclerView!!.setPadding(
+            mRecyclerView!!.getPaddingLeft(),
+            mRecyclerView!!.getPaddingTop() + statusBarHeight,
+            mRecyclerView!!.getPaddingRight(), mRecyclerView!!.getPaddingBottom()
+        )
         mRecyclerView!!.setOnItemClickListener(this)
         mRecyclerView!!.setOnItemLongClickListener(this)
         mRecyclerView!!.setChoiceMode(EasyRecyclerView.CHOICE_MODE_MULTIPLE_CUSTOM)
         mRecyclerView!!.setCustomCheckedListener(this)
 
         fastScroller.setPadding(
-            fastScroller.getPaddingLeft(), fastScroller.getPaddingTop() + paddingTopSB,
+            fastScroller.getPaddingLeft(), fastScroller.getPaddingTop() + paddingTopSB + statusBarHeight,
             fastScroller.getPaddingRight(), fastScroller.getPaddingBottom()
         )
 
-        refreshLayout.setHeaderTranslationY(paddingTopSB.toFloat())
+        refreshLayout.setHeaderTranslationY((paddingTopSB + statusBarHeight).toFloat())
 
         mLeftDrawable = DrawerArrowDrawable(
             context,
@@ -307,6 +321,10 @@ class FavoritesScene : BaseScene(), EasyRecyclerView.OnItemClickListener,
         mSearchBar!!.setHelper(this)
         mSearchBar!!.setAllowEmptySearch(false)
         updateSearchBar()
+        // Offset the floating search bar below the transparent status bar.
+        val searchBarLp = mSearchBar!!.layoutParams as ViewGroup.MarginLayoutParams
+        searchBarLp.topMargin += statusBarHeight
+        mSearchBar!!.layoutParams = searchBarLp
         mSearchBarMover = SearchBarMover(this, mSearchBar, mRecyclerView)
 
         mActionFabDrawable =

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListScene.java
@@ -657,6 +657,16 @@ public final class GalleryListScene extends BaseScene
         int paddingTopSB = resources.getDimensionPixelOffset(R.dimen.gallery_padding_top_search_bar);
         int paddingBottomFab = resources.getDimensionPixelOffset(R.dimen.gallery_padding_bottom_fab);
 
+        // Height of the transparent status bar. The scene now draws under it (see
+        // EhStageLayout#getAdditionalTopMargin), so push the floating search bar and the
+        // list's resting top down by this amount — the 瀑布流 still scrolls under the bar
+        // because the RecyclerView keeps clipToPadding=false.
+        int statusBarHeight = 0;
+        int statusBarResId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (statusBarResId > 0) {
+            statusBarHeight = resources.getDimensionPixelSize(statusBarResId);
+        }
+
 
         mViewTransition = new ViewTransition(contentLayout, mSearchLayout);
 
@@ -671,15 +681,18 @@ public final class GalleryListScene extends BaseScene
         mRecyclerView.setSelector(Ripple.generateRippleDrawable(context, !AttrResources.getAttrBoolean(context, androidx.appcompat.R.attr.isLightTheme), new ColorDrawable(Color.TRANSPARENT)));
         mRecyclerView.setDrawSelectorOnTop(true);
         mRecyclerView.setClipToPadding(false);
+        mRecyclerView.setPadding(mRecyclerView.getPaddingLeft(),
+                mRecyclerView.getPaddingTop() + statusBarHeight,
+                mRecyclerView.getPaddingRight(), mRecyclerView.getPaddingBottom());
         mRecyclerView.setOnItemClickListener(this);
         mRecyclerView.setOnItemLongClickListener(this);
         assert mOnScrollListener != null;
         mRecyclerView.addOnScrollListener(mOnScrollListener);
 //        mRecyclerView.setOnGenericMotionListener(this::onGenericMotion);
-        fastScroller.setPadding(fastScroller.getPaddingLeft(), fastScroller.getPaddingTop() + paddingTopSB,
+        fastScroller.setPadding(fastScroller.getPaddingLeft(), fastScroller.getPaddingTop() + paddingTopSB + statusBarHeight,
                 fastScroller.getPaddingRight(), fastScroller.getPaddingBottom());
 
-        refreshLayout.setHeaderTranslationY(paddingTopSB);
+        refreshLayout.setHeaderTranslationY(paddingTopSB + statusBarHeight);
 
         mLeftDrawable = new DrawerArrowDrawable(context, AttrResources.getAttrColor(context, R.attr.drawableColorPrimary));
         mRightDrawable = new AddDeleteDrawable(context, AttrResources.getAttrColor(context, R.attr.drawableColorPrimary));
@@ -690,8 +703,13 @@ public final class GalleryListScene extends BaseScene
         setSearchBarHint(context, mSearchBar);
         setSearchBarSuggestionProvider(mSearchBar);
 
+        // Offset the floating search bar below the transparent status bar.
+        ViewGroup.MarginLayoutParams searchBarLp = (ViewGroup.MarginLayoutParams) mSearchBar.getLayoutParams();
+        searchBarLp.topMargin += statusBarHeight;
+        mSearchBar.setLayoutParams(searchBarLp);
+
         mSearchLayout.setHelper(this);
-        mSearchLayout.setPadding(mSearchLayout.getPaddingLeft(), mSearchLayout.getPaddingTop() + paddingTopSB,
+        mSearchLayout.setPadding(mSearchLayout.getPaddingLeft(), mSearchLayout.getPaddingTop() + paddingTopSB + statusBarHeight,
                 mSearchLayout.getPaddingRight(), mSearchLayout.getPaddingBottom() + paddingBottomFab);
 
         mFabLayout.setAutoCancel(true);

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/topList/EhTopListScene.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/topList/EhTopListScene.kt
@@ -74,9 +74,29 @@ class EhTopListScene : BaseScene() {
     ): View {
         val view = inflater.inflate(R.layout.scene_gallery_top_list, container, false)
 
+        // The scene draws under the transparent status bar. Make the teal selector bar fill the
+        // status bar region (status bar = bar color, consistent with toolbars on other screens):
+        // dock it full-width to the very top, pad its content below the bar, then push the list
+        // down so it clears the now-taller bar.
+        val res = view.resources
+        var statusBarHeight = 0
+        val sbhId = res.getIdentifier("status_bar_height", "dimen", "android")
+        if (sbhId > 0) statusBarHeight = res.getDimensionPixelSize(sbhId)
+
         val spinner = view.findViewById<Spinner>(R.id.top_list_spinner)
         spinner.setSelection(0)
         spinner.onItemSelectedListener = TopListKindSelectedListener()
+        if (statusBarHeight > 0) {
+            val sideInset = res.getDimensionPixelOffset(R.dimen.top_list_spinner_margin)
+            (spinner.layoutParams as ViewGroup.MarginLayoutParams).let { lp ->
+                lp.leftMargin = 0
+                lp.topMargin = 0
+                lp.rightMargin = 0
+                lp.height = res.getDimensionPixelOffset(R.dimen.top_list_spinner_height) + statusBarHeight
+                spinner.layoutParams = lp
+            }
+            spinner.setPadding(sideInset, statusBarHeight + spinner.paddingTop, sideInset, spinner.paddingBottom)
+        }
 
         val frameLayout = view.findViewById<FrameLayout>(R.id.page_detail_view)
         val transitionView = view.findViewById<View>(R.id.data_loading_view)
@@ -84,6 +104,15 @@ class EhTopListScene : BaseScene() {
 
         recyclerView = view.findViewById(R.id.top_list_recycler_view)
         recyclerView?.layoutManager = LinearLayoutManager(ehContext)
+        if (statusBarHeight > 0) {
+            (recyclerView?.parent as? View)?.let { scroll ->
+                (scroll.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                    lp.topMargin = res.getDimensionPixelOffset(R.dimen.top_list_scrollview_margin_top) +
+                            statusBarHeight - res.getDimensionPixelOffset(R.dimen.top_list_spinner_margin)
+                    scroll.layoutParams = lp
+                }
+            }
+        }
 
         if (!hasFirstRefresh) {
             hasFirstRefresh = true

--- a/app/src/main/java/com/hippo/ehviewer/widget/EhDrawerView.java
+++ b/app/src/main/java/com/hippo/ehviewer/widget/EhDrawerView.java
@@ -43,11 +43,16 @@ public class EhDrawerView extends DrawerView implements DrawerLayoutChild {
     public void onGetWindowPadding(int top, int bottom) {
         mWindowPaddingTop = top;
         mWindowPaddingBottom = bottom;
+        // Let the right drawer bleed under the transparent status bar like the left
+        // navigation drawer, but keep its content (toolbar / pager tabs) below the bar.
+        if (getPaddingTop() != top) {
+            setPadding(getPaddingLeft(), top, getPaddingRight(), getPaddingBottom());
+        }
     }
 
     @Override
     public int getAdditionalTopMargin() {
-        return mWindowPaddingTop;
+        return 0;
     }
 
     public int getAdditionalBottomMargin() {

--- a/app/src/main/java/com/hippo/ehviewer/widget/EhStageLayout.java
+++ b/app/src/main/java/com/hippo/ehviewer/widget/EhStageLayout.java
@@ -47,7 +47,9 @@ public class EhStageLayout extends StageLayout implements DrawerLayoutChild {
 
     @Override
     public int getAdditionalTopMargin() {
-        return mWindowPaddingTop;
+        // Let scene content (e.g. the gallery 瀑布流 list) draw under the transparent
+        // status bar — mirrors the immersive bottom navigation bar treatment.
+        return 0;
     }
 
     @Override

--- a/app/src/main/res/layout/activity_gallery_fallback.xml
+++ b/app/src/main/res/layout/activity_gallery_fallback.xml
@@ -3,6 +3,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:padding="24dp">
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_tag_selector.xml
+++ b/app/src/main/res/layout/activity_tag_selector.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/windowBackground"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/values-v19/themes.xml
+++ b/app/src/main/res/values-v19/themes.xml
@@ -18,19 +18,16 @@
 <resources>
 
     <style name="AppTheme.NoActionBar.Translucent">
-        <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
 
     <style name="AppTheme.Dark.NoActionBar.Translucent">
-        <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
 
     <style name="AppTheme.Black.NoActionBar.Translucent">
-        <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -29,19 +29,10 @@
         <item name="android:colorEdgeEffect">?attr/colorEdgeEffect</item>
     </style>
 
-    <style name="AppTheme.NoActionBar.Translucent">
-        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
+    <style name="AppTheme.NoActionBar.Translucent" />
 
-    <style name="AppTheme.Dark.NoActionBar.Translucent">
-        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
+    <style name="AppTheme.Dark.NoActionBar.Translucent" />
 
-    <style name="AppTheme.Black.NoActionBar.Translucent">
-        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
+    <style name="AppTheme.Black.NoActionBar.Translucent" />
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -25,6 +25,8 @@
         <item name="android:navigationBarColor">@color/white</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
         <item name="buttonStyle">@style/ThemeChangeButtonStyleLight</item>
 
         <item name="android:windowBackground">@color/white</item>
@@ -97,6 +99,8 @@
         <item name="android:navigationBarColor">@color/grey_850</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="buttonStyle">@style/ThemeChangeButtonStyleDark</item>
 
         <item name="android:windowBackground">@color/grey_850</item>
@@ -163,6 +167,8 @@
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="buttonStyle">@style/ThemeChangeButtonStyleBlack</item>
 
         <item name="android:windowBackground">@android:color/black</item>


### PR DESCRIPTION
## 概要
- 恢复沉浸式透明状态栏/导航栏相关处理
- 保留并增强评论输入框的 IME inset 处理，避免键盘或透明导航栏遮挡输入面板
- 重新适配设置页、列表页、排行榜、左右抽屉的系统栏 inset

## 原因
上次回滚的根因是全局 edge-to-edge 后，评论页底部自绘输入面板没有可靠避让 IME。当前分支让输入面板取 `max(ime, systemBars)` 作为底部 margin，键盘弹出时跟随键盘，键盘收起时仍避让透明导航栏。

## 验证
- `git diff --cached --check`
- `rg -n "<<<<<<<|>>>>>>>" app/src/main app/src/main/res`
- `./gradlew.bat --no-daemon :app:assembleDebug` 成功