### PR TITLE
[Bug Fix] Fix disappearing download thumbnails

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/download/part/ThumbDataContainer.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/download/part/ThumbDataContainer.kt
@@ -31,20 +31,35 @@ import java.io.OutputStream
  * 缩略图数据容器
  */
 class ThumbDataContainer(private val mInfo: DownloadInfo) : DataContainer {
+    private var mDirectory: UniFile? = null
     private var mFile: UniFile? = null
 
-    private fun ensureFile() {
-        if (mFile == null) {
-            val dir = SpiderDen.getGalleryDownloadDir(mInfo)
+    private fun ensureDirectory(): UniFile? {
+        if (mDirectory == null) {
+            val dir = SpiderDen.getExistingGalleryDownloadDir(mInfo)
             if (dir != null && dir.isDirectory()) {
-                mFile = dir.createFile(".thumb")
+                mDirectory = dir
             }
         }
+        return mDirectory
+    }
+
+    private fun findExistingFile(): UniFile? {
+        val dir = ensureDirectory() ?: return null
+        val file = dir.findFile(".thumb")
+        if (file == null || !file.isFile) return null
+        if (file.length() <= 0L) {
+            file.delete()
+            return null
+        }
+        mFile = file
+        return file
     }
 
     override fun isEnabled(): Boolean {
-        ensureFile()
-        return mFile != null
+        // Reading must never create .thumb. A missing file means Conaco should continue to the
+        // network source; the directory is needed only if that response is later saved.
+        return ensureDirectory() != null
     }
 
     override fun onUrlMoved(requestUrl: String?, responseUrl: String?) {
@@ -56,36 +71,38 @@ class ThumbDataContainer(private val mInfo: DownloadInfo) : DataContainer {
         mediaType: String?,
         notify: ProgressNotifier?
     ): Boolean {
-        ensureFile()
-        if (mFile == null) {
-            return false
-        }
+        val dir = ensureDirectory() ?: return false
+        val temporaryName = ".thumb.tmp-${System.nanoTime().toString(16)}"
+        val temporary = dir.createFile(temporaryName) ?: return false
 
         var os: OutputStream? = null
         try {
-            os = mFile!!.openOutputStream()
+            os = temporary.openOutputStream()
             IOUtils.copy(`is`, os)
-            return true
+            IOUtils.closeQuietly(os)
+            os = null
+            if (temporary.length() <= 0L) return false
+            val old = dir.findFile(".thumb")
+            if (old != null && !old.delete()) return false
+            if (!temporary.renameTo(".thumb")) return false
+            mFile = dir.findFile(".thumb")
+            return mFile != null
         } catch (e: IOException) {
             e.printStackTrace()
             return false
         } finally {
             IOUtils.closeQuietly(os)
+            if (temporary.exists()) temporary.delete()
         }
     }
 
     override fun get(): InputStreamPipe? {
-        ensureFile()
-        if (mFile != null) {
-            return UniFileInputStreamPipe(mFile)
-        } else {
-            return null
-        }
+        val file = findExistingFile() ?: return null
+        return UniFileInputStreamPipe(file)
     }
 
     override fun remove() {
-        if (mFile != null) {
-            mFile!!.delete()
-        }
+        findExistingFile()?.delete()
+        mFile = null
     }
 }


### PR DESCRIPTION
## 对比基线

本 PR 对比上游 `BiLi_PC_Gamer` 的 `20bea75`。该提交也是当前 PR 的 base commit。

## 基线中的缩略图缓存实现

- `ThumbDataContainer` 只保存一个 `mFile` 引用。
- `ensureFile()` 调用 `SpiderDen.getGalleryDownloadDir(mInfo)` 获取目录，并调用 `createFile(".thumb")`。
- `isEnabled()` 调用 `ensureFile()`，然后根据 `mFile != null` 返回结果。
- `onWrite()` 直接打开最终 `.thumb` 文件的输出流，将输入流复制到该文件后返回 `true`。
- 基线实现不使用临时文件，也不在写入后检查文件长度。
- `get()` 通过 `mFile` 创建 `UniFileInputStreamPipe`。
- `remove()` 在 `mFile` 非空时删除该文件。

## 本 PR 的代码变化

- 增加 `mDirectory` 引用，将目录查找和 `.thumb` 文件查找分开。
- `ensureDirectory()` 改用 `SpiderDen.getExistingGalleryDownloadDir(mInfo)`，只返回已经存在的下载目录。
- 新增 `findExistingFile()`：
  - 通过 `findFile(".thumb")` 查找现有文件；
  - 检查目标是文件；
  - 当文件长度小于等于 0 时删除该文件并返回 `null`。
- `isEnabled()` 只检查现有下载目录是否可用，不再创建 `.thumb`。
- `onWrite()` 的写入流程改为：
  1. 在同一目录创建名称带 `System.nanoTime()` 的 `.thumb.tmp-*` 文件；
  2. 将输入流写入临时文件并关闭输出流；
  3. 检查临时文件长度大于 0；
  4. 删除已有 `.thumb`；
  5. 将临时文件重命名为 `.thumb`；
  6. 重新查找最终文件并更新 `mFile`。
- `finally` 中关闭输出流，并在临时文件仍存在时将其删除。
- `get()` 只为 `findExistingFile()` 返回的有效文件创建输入流。
- `remove()` 查找并删除现有 `.thumb`，随后清空 `mFile` 引用。

## 未修改的范围

- `DataContainer` 接口未修改。
- `onUrlMoved()` 行为未修改。
- 网络缩略图请求、图片解码和 RecyclerView Adapter 未修改。
- 本 PR 不包含 NAS 同步或分页控件代码。

## 变更文件

- `app/src/main/java/com/hippo/ehviewer/ui/scene/download/part/ThumbDataContainer.kt`

相对 base 的统计为 38 行新增、21 行删除。

## 验证

- `./gradlew assembleAppReleaseDebug --no-daemon --console=plain`
- 结果：`BUILD SUCCESSFUL`
