### PR TITLE
igneous 刷新按键 & 使用 CF-Connecting-IP 头获取 igneous

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/EhApplication.java
+++ b/app/src/main/java/com/hippo/ehviewer/EhApplication.java
@@ -98,6 +98,7 @@ import okhttp3.Cache;
 import okhttp3.ConnectionPool;
 import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okhttp3.Response;
 
 public class EhApplication extends RecordingApplication {
@@ -177,6 +178,9 @@ public class EhApplication extends RecordingApplication {
         GetText.initialize(this);
         StatusCodeException.initialize(this);
         Settings.initialize(this);
+        if (Settings.getCfConnectingIp() == null) {
+            Settings.putCfConnectingIp(Settings.generateUsWarpIp());
+        }
         ArchiverDownloadCompleter.resumePendingDownloads(this);
         ReadableTime.initialize(this);
         Html.initialize(this);
@@ -402,10 +406,44 @@ public class EhApplication extends RecordingApplication {
                     .cache(getOkHttpCache(application))
 //                    .hostnameVerifier((hostname, session) -> true)
 //                    .dispatcher(dispatcher)
+                    .addInterceptor(chain -> {
+                        Request request = chain.request();
+                        Response response = chain.proceed(request);
+                        if ("exhentai.org".equals(request.url().host())) {
+                            boolean mysteryIgneous = false;
+                            for (String setCookie : response.headers("Set-Cookie")) {
+                                if (setCookie.contains("igneous=mystery")) {
+                                    mysteryIgneous = true;
+                                    break;
+                                }
+                            }
+                            if (mysteryIgneous && Settings.getCfAutoRetry()) {
+                                response.close();
+                                String cfIp = Settings.getCfConnectingIp();
+                                if (cfIp != null && !cfIp.isEmpty()) {
+                                    Request retryRequest = request.newBuilder()
+                                            .header("CF-Connecting-IP", cfIp)
+                                            .header("X-Retry-Igneous", "1")
+                                            .build();
+                                    response = chain.proceed(retryRequest);
+                                }
+                            }
+                        }
+                        return response;
+                    })
                     .dns(new EhHosts(application))
-                    .addNetworkInterceptor(sprocket -> {
+                    .addNetworkInterceptor(chain -> {
+                        Request request = chain.request();
+                        if (request.header("X-Retry-Igneous") != null) {
+                            String cookieHeader = request.header("Cookie");
+                            String filtered = stripCookie(cookieHeader, "igneous");
+                            request = request.newBuilder()
+                                    .removeHeader("X-Retry-Igneous")
+                                    .header("Cookie", filtered)
+                                    .build();
+                        }
                         try {
-                            return sprocket.proceed(sprocket.request());
+                            return chain.proceed(request);
                         } catch (NullPointerException e) {
                             throw new NullPointerException(e.getMessage());
                         }
@@ -637,6 +675,19 @@ public class EhApplication extends RecordingApplication {
     @NonNull
     public static String getDeveloperEmail() {
         return "xiaojieonly$foxmail.com".replace('$', '@');
+    }
+
+    private static String stripCookie(String cookieHeader, String cookieName) {
+        if (cookieHeader == null) return "";
+        StringBuilder result = new StringBuilder();
+        for (String part : cookieHeader.split(";")) {
+            String trimmed = part.trim();
+            if (!trimmed.startsWith(cookieName + "=") && !trimmed.equals(cookieName)) {
+                if (result.length() > 0) result.append("; ");
+                result.append(trimmed);
+            }
+        }
+        return result.toString();
     }
 
     public void registerActivity(Activity activity) {

--- a/app/src/main/java/com/hippo/ehviewer/Settings.java
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.java
@@ -1335,6 +1335,39 @@ public class Settings {
     }
 
 
+    public static final String KEY_CF_AUTO_RETRY = "cf_auto_retry";
+
+    public static boolean getCfAutoRetry() {
+        return getBoolean(KEY_CF_AUTO_RETRY, false);
+    }
+
+    public static void putCfAutoRetry(boolean value) {
+        putBoolean(KEY_CF_AUTO_RETRY, value);
+    }
+
+    public static final String KEY_CF_CONNECTING_IP = "cf_connecting_ip";
+
+    public static String getCfConnectingIp() {
+        return getString(KEY_CF_CONNECTING_IP, null);
+    }
+
+    public static void putCfConnectingIp(String value) {
+        putString(KEY_CF_CONNECTING_IP, value);
+    }
+
+    public static String generateUsWarpIp() {
+        java.util.Random random = new java.util.Random();
+        char[] choices = {'8', 'a', 'c', 'e'};
+        char x = choices[random.nextInt(4)];
+        int cityFirstNibble = random.nextInt(10);
+        int cityRest = random.nextInt(0x1000);
+        int rand7 = random.nextInt(0x1000);
+        int rand8 = random.nextInt(0x1000);
+        return String.format("2a09:bac1:76%c0:%x%03x:0000:0000:0%03x:0%03x",
+                x, cityFirstNibble, cityRest, rand7, rand8);
+    }
+
+
     private static final String KEY_DOWNLOAD_DELAY = "download_delay";
     private static final int DEFAULT_DOWNLOAD_DELAY = 0;
 

--- a/app/src/main/java/com/hippo/ehviewer/client/EhCookieStore.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhCookieStore.java
@@ -56,6 +56,17 @@ public class EhCookieStore extends CookieRepository {
                 contains(url, KEY_IPD_PASS_HASH);
     }
 
+    public void removeIgneous() {
+        HttpUrl exUrl = HttpUrl.parse(EhUrl.HOST_EX);
+        if (exUrl == null) return;
+        addCookie(new Cookie.Builder()
+                .name(KEY_IGNEOUS)
+                .value("deleted")
+                .domain(exUrl.host())
+                .expiresAt(0)
+                .build());
+    }
+
     public static Cookie newCookie(Cookie cookie, String newDomain, boolean forcePersistent,
             boolean forceLongLive, boolean forceNotHostOnly) {
         Cookie.Builder builder = new Cookie.Builder();

--- a/app/src/main/java/com/hippo/ehviewer/preference/IdentityCookiePreference.java
+++ b/app/src/main/java/com/hippo/ehviewer/preference/IdentityCookiePreference.java
@@ -19,12 +19,17 @@ package com.hippo.ehviewer.preference;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.AttributeSet;
+import android.widget.Button;
 import android.widget.Toast;
 import androidx.appcompat.app.AlertDialog;
 import com.hippo.ehviewer.EhApplication;
 import com.hippo.ehviewer.R;
 import com.hippo.ehviewer.client.EhCookieStore;
+import com.hippo.ehviewer.client.EhRequestBuilder;
 import com.hippo.ehviewer.client.EhUrl;
 import com.hippo.preference.MessagePreference;
 import com.hippo.text.Html;
@@ -32,10 +37,15 @@ import java.util.LinkedList;
 import java.util.List;
 import okhttp3.Cookie;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public class IdentityCookiePreference extends MessagePreference {
 
+    private AlertDialog mDialog;
     private String message;
+    private CharSequence mDialogMessage;
 
     public IdentityCookiePreference(Context context) {
         super(context);
@@ -82,10 +92,13 @@ public class IdentityCookiePreference extends MessagePreference {
             message = EhCookieStore.KEY_IPD_MEMBER_ID + ": " + ipbMemberId + "<br>"
                     + EhCookieStore.KEY_IPD_PASS_HASH + ": " + ipbPassHash + "<br>"
                     + EhCookieStore.KEY_IGNEOUS + ": " + igneous;
-            setDialogMessage(Html.fromHtml(getContext().getString(R.string.settings_eh_identity_cookies_signed, message)));
+            mDialogMessage = Html.fromHtml(getContext().getString(R.string.settings_eh_identity_cookies_signed, message));
+            setDialogMessage(mDialogMessage);
             message = message.replace("<br>", "\n");
         } else {
-            setDialogMessage(getContext().getString(R.string.settings_eh_identity_cookies_tourist));
+            message = null;
+            mDialogMessage = getContext().getString(R.string.settings_eh_identity_cookies_tourist);
+            setDialogMessage(mDialogMessage);
         }
     }
 
@@ -100,6 +113,39 @@ public class IdentityCookiePreference extends MessagePreference {
 
                 IdentityCookiePreference.this.onClick(dialog, which);
             });
+            builder.setNeutralButton(R.string.settings_eh_refresh_igneous, null);
         }
+    }
+
+    @Override
+    protected void onDialogCreated(AlertDialog dialog) {
+        super.onDialogCreated(dialog);
+        mDialog = dialog;
+        Button refreshBtn = dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
+        if (refreshBtn != null) {
+            refreshBtn.setOnClickListener(v -> performIgneousRefresh(refreshBtn));
+        }
+    }
+
+    private void performIgneousRefresh(Button btn) {
+        btn.setEnabled(false);
+        EhApplication.getEhCookieStore(getContext()).removeIgneous();
+        OkHttpClient client = EhApplication.getOkHttpClient(getContext());
+        new Thread(() -> {
+            try {
+                Request request = new EhRequestBuilder(EhUrl.URL_UCONFIG_EX).build();
+                try (Response response = client.newCall(request).execute()) {
+                    // cookie jar updated by interceptors
+                }
+            } catch (Exception ignored) {
+            }
+            new Handler(Looper.getMainLooper()).post(() -> {
+                init();
+                if (mDialog != null && mDialog.isShowing()) {
+                    mDialog.setMessage(mDialogMessage);
+                }
+                btn.setEnabled(true);
+            });
+        }).start();
     }
 }

--- a/app/src/main/java/com/hippo/ehviewer/ui/fragment/AdvancedFragment.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/fragment/AdvancedFragment.java
@@ -29,12 +29,14 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.EditTextPreference;
 import androidx.preference.Preference;
 
 import com.hippo.ehviewer.AppConfig;
 import com.hippo.ehviewer.EhApplication;
 import com.hippo.ehviewer.EhDB;
 import com.hippo.ehviewer.R;
+import com.hippo.ehviewer.Settings;
 import com.hippo.ehviewer.ui.wifi.WiFiClientActivity;
 import com.hippo.ehviewer.ui.wifi.WiFiServerActivity;
 import com.hippo.ehviewer.widget.ProgressHelper;
@@ -58,6 +60,8 @@ public class AdvancedFragment extends BasePreferenceFragmentCompat
     private static final String KEY_IMPORT_DATA = "import_data";
     private static final String KEY_WIFI_SERVER = "wifi_server";
     private static final String KEY_WIFI_CLIENT = "wifi_client";
+    private static final String KEY_CF_AUTO_RETRY = Settings.KEY_CF_AUTO_RETRY;
+    private static final String KEY_CF_CONNECTING_IP = Settings.KEY_CF_CONNECTING_IP;
 
     private final DbSyncHandle dbSyncHandle = new DbSyncHandle(Looper.getMainLooper());
 
@@ -74,6 +78,7 @@ public class AdvancedFragment extends BasePreferenceFragmentCompat
         Preference importData = findPreference(KEY_IMPORT_DATA);
         Preference socketData = findPreference(KEY_WIFI_SERVER);
         Preference clientData = findPreference(KEY_WIFI_CLIENT);
+        EditTextPreference cfConnectingIp = findPreference(KEY_CF_CONNECTING_IP);
 
         dumpLogcat.setOnPreferenceClickListener(this);
         clearMemoryCache.setOnPreferenceClickListener(this);
@@ -82,6 +87,13 @@ public class AdvancedFragment extends BasePreferenceFragmentCompat
         clientData.setOnPreferenceClickListener(this);
 
         appLanguage.setOnPreferenceChangeListener(this);
+
+        if (cfConnectingIp != null) {
+            String currentIp = Settings.getCfConnectingIp();
+            cfConnectingIp.setText(currentIp);
+            cfConnectingIp.setSummary(currentIp);
+            cfConnectingIp.setOnPreferenceChangeListener(this);
+        }
     }
 
     @Override
@@ -190,6 +202,10 @@ public class AdvancedFragment extends BasePreferenceFragmentCompat
         String key = preference.getKey();
         if (KEY_APP_LANGUAGE.equals(key)) {
             ((EhApplication) getActivity().getApplication()).recreate();
+            return true;
+        }
+        if (KEY_CF_CONNECTING_IP.equals(key)) {
+            preference.setSummary((String) newValue);
             return true;
         }
         return false;

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -698,6 +698,7 @@
     <string name="settings_advanced_dns_over_http_summary">解决某些地区的 DNS 污染问题</string>
     <string name="settings_advanced_domain_fronting_title">域名前置</string>
     <string name="settings_advanced_domain_fronting_summary">绕过 SNI 封锁</string>
+    <string name="settings_eh_refresh_igneous">刷新 IGNEOUS</string>
     <string name="settings_advanced_url_replace_title">url伪装,需关闭SNI</string>
     <string name="settings_advanced_url_replace_summary">url伪装(需重启，开启后账户功能失效)</string>
     <string name="share_favorites_dialog_title">分享收藏</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -699,6 +699,10 @@
     <string name="settings_advanced_domain_fronting_title">域名前置</string>
     <string name="settings_advanced_domain_fronting_summary">绕过 SNI 封锁</string>
     <string name="settings_eh_refresh_igneous">刷新 IGNEOUS</string>
+    <string name="settings_advanced_cf_auto_retry_title">IGNEOUS 自动重试</string>
+    <string name="settings_advanced_cf_auto_retry_summary">igneous=mystery 时自动使用 CF-Connecting-IP 重试</string>
+    <string name="settings_advanced_cf_connecting_ip_title">CF-Connecting-IP</string>
+    <string name="settings_advanced_cf_connecting_ip_summary">CF-Connecting-IP 头内的伪装 IP 地址</string>
     <string name="settings_advanced_url_replace_title">url伪装,需关闭SNI</string>
     <string name="settings_advanced_url_replace_summary">url伪装(需重启，开启后账户功能失效)</string>
     <string name="share_favorites_dialog_title">分享收藏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,10 @@
     <string name="settings_advanced_domain_fronting_title">域名前置</string>
     <string name="settings_advanced_domain_fronting_summary">绕过 SNI 封锁</string>
     <string name="settings_eh_refresh_igneous">REFRESH IGNEOUS</string>
+    <string name="settings_advanced_cf_auto_retry_title">IGNEOUS auto-retry</string>
+    <string name="settings_advanced_cf_auto_retry_summary">Retry with CF-Connecting-IP if igneous=mystery</string>
+    <string name="settings_advanced_cf_connecting_ip_title">CF-Connecting-IP</string>
+    <string name="settings_advanced_cf_connecting_ip_summary">IP address to spoof in CF-Connecting-IP header</string>
     <string name="settings_advanced_url_replace_title">url伪装,需关闭SNI</string>
     <string name="settings_advanced_url_replace_summary">url伪装(需重启，开启后账户功能失效)</string>
     <string name="settings_about_donate_guide">支持指南</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="settings_advanced_dns_over_http_summary">解决某些地区的 DNS 污染问题</string>
     <string name="settings_advanced_domain_fronting_title">域名前置</string>
     <string name="settings_advanced_domain_fronting_summary">绕过 SNI 封锁</string>
+    <string name="settings_eh_refresh_igneous">REFRESH IGNEOUS</string>
     <string name="settings_advanced_url_replace_title">url伪装,需关闭SNI</string>
     <string name="settings_advanced_url_replace_summary">url伪装(需重启，开启后账户功能失效)</string>
     <string name="settings_about_donate_guide">支持指南</string>

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -101,6 +101,18 @@
         android:summary="@string/settings_advanced_domain_fronting_summary"
         android:title="@string/settings_advanced_domain_fronting_title" />
 
+    <com.hippo.preference.SwitchPreference
+        android:defaultValue="false"
+        android:key="cf_auto_retry"
+        android:summary="@string/settings_advanced_cf_auto_retry_summary"
+        android:title="@string/settings_advanced_cf_auto_retry_title"
+        app:allowDividerAbove="true" />
+
+    <androidx.preference.EditTextPreference
+        android:key="cf_connecting_ip"
+        android:title="@string/settings_advanced_cf_connecting_ip_title"
+        android:dialogTitle="@string/settings_advanced_cf_connecting_ip_title" />
+
     <!--    <com.hippo.preference.SwitchPreference-->
     <!--        android:defaultValue="false"-->
     <!--        android:key="url_replace"-->


### PR DESCRIPTION
TLDR: igneous 过期时用户无需挂美国梯子重新登录，只要打开 CF-Connecting-IP 自动重试然后点一次刷新 igneous。

---

Cloudflare 会传递客户端 IP 地址在 HTTP 请求头  CF-Connecting-IP 给 exhentai 源站，当我们直接访问源站时，可以自己设置这个头给 exhentai 伪造我们的 IP 地址。

1. 首次启动时随机生成 Cloudflare WARP 美国出口 IPv6 地址 `^2a09:bac1:76[8ace]0:[0-9][0-9a-f]{3}:0000:0000:0[0-9a-f]{3}:0[0-9a-f]{3}$` 存入设置项，该项用户可修改（可按需修改为账户注册地所在国地址）。
2. EH - 身份 Cookie 页面添加刷新 igneous 按键。
3. 添加遇到 igneous=mystery 时加 CF-Connecting-IP 的自动重试开关。自动重试默认关闭。

以下是重试的示例，第一次请求直连，服务端返回 igneous=mystery，第二次加上 CF-Connecting-IP 和美国 IP 头之后，成功获取到 igneous。

<img width="1080" height="2113" alt="Screenshot_20260716-184405" src="https://github.com/user-attachments/assets/2e245b4c-3693-4b59-8053-babafedc5830" />
