### PR TITLE
fix: 完善本地压缩包导入与阅读进度

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/EhDB.java
+++ b/app/src/main/java/com/hippo/ehviewer/EhDB.java
@@ -469,8 +469,23 @@ public class EhDB {
         }
     }
 
+    // Insert or update a group of downloads in one transaction.
+    public static synchronized void putDownloadInfoList(List<DownloadInfo> downloadInfoList) {
+        if (downloadInfoList == null || downloadInfoList.isEmpty()) {
+            return;
+        }
+        sDaoSession.getDownloadsDao().insertOrReplaceInTx(downloadInfoList);
+    }
+
     public static synchronized void removeDownloadInfo(long gid) {
         sDaoSession.getDownloadsDao().deleteByKey(gid);
+    }
+
+    public static synchronized void removeDownloadInfoList(List<DownloadInfo> downloadInfoList) {
+        if (downloadInfoList == null || downloadInfoList.isEmpty()) {
+            return;
+        }
+        sDaoSession.getDownloadsDao().deleteInTx(downloadInfoList);
     }
 
     @Nullable

--- a/app/src/main/java/com/hippo/ehviewer/Settings.java
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.java
@@ -53,17 +53,25 @@ import java.util.Map;
 public class Settings {
 
     private static final String TAG = Settings.class.getSimpleName();
+    private static final String ARCHIVE_READING_PROGRESS_PREFS = "archive_reading_progress";
+    private static final String ARCHIVE_PAGE_COUNT_PREFS = "archive_page_count";
 
     @SuppressLint("StaticFieldLeak")
     private static Context sContext;
     private static SharedPreferences sSettingsPre;
     private static SharedPreferences sArchiverPre;
+    private static SharedPreferences sArchiveReadingProgressPre;
+    private static SharedPreferences sArchivePageCountPre;
     private static EhConfig sEhConfig;
 
     public static void initialize(Context context) {
         sContext = context.getApplicationContext();
         sSettingsPre = PreferenceManager.getDefaultSharedPreferences(sContext);
         sArchiverPre = context.getSharedPreferences("archiver_cache",Context.MODE_PRIVATE);
+        sArchiveReadingProgressPre = sContext.getSharedPreferences(
+                ARCHIVE_READING_PROGRESS_PREFS, Context.MODE_PRIVATE);
+        sArchivePageCountPre = sContext.getSharedPreferences(
+                ARCHIVE_PAGE_COUNT_PREFS, Context.MODE_PRIVATE);
         sEhConfig = loadEhConfig();
         if (getDarkModeStatus(context) && isThemeAutoSwitchAvailable()) {
             putTheme(THEME_DARK);
@@ -96,6 +104,73 @@ public class Settings {
         ehConfig.excludedNamespaces = getExcludedTagNamespaces();
         ehConfig.setDirty();
         return ehConfig;
+    }
+
+    public static int getArchiveReadingProgress(long gid) {
+        if (gid < 0) {
+            return 0;
+        }
+        return Math.max(sArchiveReadingProgressPre.getInt(Long.toString(gid), 0), 0);
+    }
+
+    public static void putArchiveReadingProgress(long gid, int page) {
+        if (gid < 0 || page < 0) {
+            return;
+        }
+        String key = Long.toString(gid);
+        SharedPreferences.Editor editor = sArchiveReadingProgressPre.edit();
+        if (page == 0) {
+            editor.remove(key);
+        } else {
+            editor.putInt(key, page);
+        }
+        editor.apply();
+    }
+
+    public static int getArchivePageCount(long gid) {
+        if (gid < 0) {
+            return 0;
+        }
+        return Math.max(sArchivePageCountPre.getInt(Long.toString(gid), 0), 0);
+    }
+
+    public static void putArchivePageCount(long gid, int pageCount) {
+        if (gid < 0 || pageCount < 0) {
+            return;
+        }
+        String key = Long.toString(gid);
+        SharedPreferences.Editor editor = sArchivePageCountPre.edit();
+        if (pageCount == 0) {
+            editor.remove(key);
+        } else {
+            editor.putInt(key, pageCount);
+        }
+        editor.apply();
+    }
+
+    public static void removeArchiveReadingProgress(long... gids) {
+        if (gids == null || gids.length == 0) {
+            return;
+        }
+        SharedPreferences.Editor progressEditor = sArchiveReadingProgressPre.edit();
+        SharedPreferences.Editor pageCountEditor = sArchivePageCountPre.edit();
+        boolean changed = false;
+        for (long gid : gids) {
+            if (gid >= 0) {
+                String key = Long.toString(gid);
+                progressEditor.remove(key);
+                pageCountEditor.remove(key);
+                changed = true;
+            }
+        }
+        if (changed) {
+            progressEditor.apply();
+            pageCountEditor.apply();
+        }
+    }
+
+    public static void clearArchiveReadingProgress() {
+        sArchiveReadingProgressPre.edit().clear().apply();
     }
 
     public static GalleryInfo getArchiverDownload(long downloadId){

--- a/app/src/main/java/com/hippo/ehviewer/download/DownloadManager.java
+++ b/app/src/main/java/com/hippo/ehviewer/download/DownloadManager.java
@@ -54,10 +54,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class DownloadManager implements SpiderQueen.OnSpiderListener {
 
@@ -199,6 +201,21 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
         }
     }
 
+    @NonNull
+    private LinkedList<DownloadInfo> getOrCreateInfoListForLabel(@Nullable String label) {
+        LinkedList<DownloadInfo> list = getInfoListForLabel(label);
+        if (list != null) {
+            return list;
+        }
+        list = new LinkedList<>();
+        mMap.put(label, list);
+        if (!containLabel(label)) {
+            mLabelList.add(EhDB.addDownloadLabel(label));
+        }
+        mLabelCountMap.put(label, 0L);
+        return list;
+    }
+
     public boolean containLabel(String label) {
         if (label == null) {
             return false;
@@ -215,6 +232,31 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
 
     public boolean containDownloadInfo(long gid) {
         return mAllInfoMap.indexOfKey(gid) >= 0;
+    }
+
+    private static boolean hasArchiveUriReference(Iterable<DownloadInfo> infos, String archiveUri) {
+        if (infos == null || archiveUri == null) {
+            return false;
+        }
+        for (DownloadInfo info : infos) {
+            if (info != null && archiveUri.equals(info.archiveUri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void releaseArchiveUriPermissionIfUnused(@Nullable String archiveUri) {
+        if (archiveUri == null || !archiveUri.startsWith("content://") ||
+                hasArchiveUriReference(mAllInfoList, archiveUri)) {
+            return;
+        }
+        try {
+            mContext.getContentResolver().releasePersistableUriPermission(
+                    Uri.parse(archiveUri), Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Failed to release URI permission for " + archiveUri, e);
+        }
     }
 
     @NonNull
@@ -520,9 +562,13 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
         }
     }
 
-    public void addDownload(List<DownloadInfo> downloadInfoList) {
+    @NonNull
+    public List<DownloadInfo> addDownload(List<DownloadInfo> downloadInfoList) {
+        List<DownloadInfo> newInfos = new ArrayList<>(downloadInfoList.size());
+        Set<Long> newGids = new HashSet<>();
+
         for (DownloadInfo info : downloadInfoList) {
-            if (containDownloadInfo(info.gid)) {
+            if (info == null || containDownloadInfo(info.gid) || !newGids.add(info.gid)) {
                 // Contain
                 continue;
             }
@@ -533,31 +579,39 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
                 info.state = DownloadInfo.STATE_NONE;
             }
 
-            // Add to label download list
-            LinkedList<DownloadInfo> list = getInfoListForLabel(info.label);
-            if (null == list) {
-                // Can't find the label in label list
-                list = new LinkedList<>();
-                mMap.put(info.label, list);
-                if (!containLabel(info.label)) {
-                    // Add label to DB and list
-                    mLabelList.add(EhDB.addDownloadLabel(info.label));
-                }
-            }
+            // Ensure the label exists before the database transaction.
+            getOrCreateInfoListForLabel(info.label);
+
+            newInfos.add(info);
+        }
+
+        EhDB.putDownloadInfoList(newInfos);
+
+        Set<String> affectedLabels = new HashSet<>();
+        for (DownloadInfo info : newInfos) {
+            // A database restore may run off the main thread. If a label was removed while
+            // the transaction ran, restore it so the committed row and manager stay aligned.
+            LinkedList<DownloadInfo> list = getOrCreateInfoListForLabel(info.label);
             list.add(info);
-            // Sort
-            Collections.sort(list, DATE_DESC_COMPARATOR);
+            affectedLabels.add(info.label);
 
             // Add to all download list and map
             mAllInfoList.add(info);
             mAllInfoMap.put(info.gid, info);
+        }
 
-            // Save to
-            EhDB.putDownloadInfo(info);
+        for (String label : affectedLabels) {
+            LinkedList<DownloadInfo> list = getInfoListForLabel(label);
+            if (list != null) {
+                Collections.sort(list, DATE_DESC_COMPARATOR);
+                mLabelCountMap.put(label, (long) list.size());
+            }
         }
 
         // Sort all download list
-        Collections.sort(mAllInfoList, DATE_DESC_COMPARATOR);
+        if (!newInfos.isEmpty()) {
+            Collections.sort(mAllInfoList, DATE_DESC_COMPARATOR);
+        }
 
         // Notify
         new Handler(Looper.getMainLooper()).post(() -> {
@@ -565,6 +619,7 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
                 l.onReload();
             }
         });
+        return newInfos;
     }
 
     public void addDownloadLabel(List<DownloadLabel> downloadLabelList) {
@@ -712,8 +767,10 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
         stopDownloadInternal(gid);
         DownloadInfo info = mAllInfoMap.get(gid);
         if (info != null) {
+            String archiveUri = info.archiveUri;
             // Remove from DB
             EhDB.removeDownloadInfo(info.gid);
+            Settings.removeArchiveReadingProgress(info.gid);
 
             // Remove all list and map
             mAllInfoList.remove(info);
@@ -725,12 +782,15 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
                 int index = list.indexOf(info);
                 if (index >= 0) {
                     list.remove(info);
+                    mLabelCountMap.put(info.label, (long) list.size());
                     // Update listener
                     for (DownloadInfoListener l : mDownloadInfoListeners) {
                         l.onRemove(info, list, index);
                     }
                 }
             }
+
+            releaseArchiveUriPermissionIfUnused(archiveUri);
 
             // Ensure download
             ensureDownload();
@@ -739,19 +799,35 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
 
     public void deleteRangeDownload(LongList gidList) {
         stopRangeDownloadInternal(gidList);
+        List<DownloadInfo> removedInfos = new ArrayList<>(gidList.size());
+        Set<Long> removedGidSet = new HashSet<>();
 
         for (int i = 0, n = gidList.size(); i < n; i++) {
             long gid = gidList.get(i);
+            if (!removedGidSet.add(gid)) {
+                continue;
+            }
             DownloadInfo info = mAllInfoMap.get(gid);
             if (null == info) {
                 Log.d(TAG, "Can't get download info with gid: " + gid);
                 continue;
             }
+            removedInfos.add(info);
+        }
 
-            // Remove from DB
-            EhDB.removeDownloadInfo(info.gid);
+        // Delete all database rows atomically before changing the in-memory state.
+        EhDB.removeDownloadInfoList(removedInfos);
 
-            // Remove from all info map
+        long[] removedGids = new long[removedInfos.size()];
+        Set<String> removedArchiveUris = new HashSet<>();
+        for (int i = 0; i < removedInfos.size(); i++) {
+            DownloadInfo info = removedInfos.get(i);
+            removedGids[i] = info.gid;
+            if (info.archiveUri != null) {
+                removedArchiveUris.add(info.archiveUri);
+            }
+
+            // Remove from all info list and map
             mAllInfoList.remove(info);
             mAllInfoMap.remove(info.gid);
 
@@ -759,7 +835,12 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
             LinkedList<DownloadInfo> list = getInfoListForLabel(info.label);
             if (list != null) {
                 list.remove(info);
+                mLabelCountMap.put(info.label, (long) list.size());
             }
+        }
+        Settings.removeArchiveReadingProgress(removedGids);
+        for (String archiveUri : removedArchiveUris) {
+            releaseArchiveUriPermissionIfUnused(archiveUri);
         }
 
         // Update listener
@@ -773,6 +854,7 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
 
     @SuppressLint("StaticFieldLeak")
     public void resetAllReadingProgress() {
+        Settings.clearArchiveReadingProgress();
         LinkedList<DownloadInfo> list = new LinkedList<>(mAllInfoList);
 
         new AsyncTask<Void, Void, Void>() {
@@ -918,15 +1000,21 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
                 continue;
             }
 
-            List<DownloadInfo> srcList = getInfoListForLabel(info.label);
+            String sourceLabel = info.label;
+            List<DownloadInfo> srcList = getInfoListForLabel(sourceLabel);
             if (srcList == null) {
-                Log.e(TAG, "Can't find label with label: " + info.label);
+                Log.e(TAG, "Can't find label with label: " + sourceLabel);
                 continue;
             }
 
-            srcList.remove(info);
+            if (!srcList.remove(info)) {
+                Log.e(TAG, "Can't find download info in label: " + sourceLabel);
+                continue;
+            }
             dstList.add(info);
             info.label = label;
+            mLabelCountMap.put(sourceLabel, (long) srcList.size());
+            mLabelCountMap.put(label, (long) dstList.size());
             Collections.sort(dstList, DATE_DESC_COMPARATOR);
 
             // Save to DB
@@ -945,6 +1033,7 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
 
         mLabelList.add(EhDB.addDownloadLabel(label));
         mMap.put(label, new LinkedList<>());
+        mLabelCountMap.put(label, 0L);
 
         for (DownloadInfoListener l : mDownloadInfoListeners) {
             l.onUpdateLabels();
@@ -999,6 +1088,8 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
         }
         // Put list back with new label
         mMap.put(to, list);
+        mLabelCountMap.remove(from);
+        mLabelCountMap.put(to, (long) list.size());
 
         // Notify listener
         for (DownloadInfoListener l : mDownloadInfoListeners) {
@@ -1023,6 +1114,7 @@ public class DownloadManager implements SpiderQueen.OnSpiderListener {
         }
 
         LinkedList<DownloadInfo> list = mMap.remove(label);
+        mLabelCountMap.remove(label);
         if (list == null) {
             return;
         }

--- a/app/src/main/java/com/hippo/ehviewer/gallery/ArchiveGalleryProvider.java
+++ b/app/src/main/java/com/hippo/ehviewer/gallery/ArchiveGalleryProvider.java
@@ -25,6 +25,7 @@ import androidx.annotation.Nullable;
 import com.hippo.a7zip.ArchiveException;
 import com.hippo.ehviewer.GetText;
 import com.hippo.ehviewer.R;
+import com.hippo.ehviewer.Settings;
 import com.hippo.lib.glgallery.GalleryPageView;
 import com.hippo.lib.image.Image;
 //import com.hippo.lib.image.Image1;
@@ -49,6 +50,9 @@ public class ArchiveGalleryProvider extends GalleryProvider2 {
   private static final AtomicInteger sIdGenerator = new AtomicInteger();
 
   private final UniFile file;
+  private final long galleryId;
+  private final Object startPageLock = new Object();
+  private int startPage;
 
   private Thread archiveThread;
   private Thread decodeThread;
@@ -62,7 +66,17 @@ public class ArchiveGalleryProvider extends GalleryProvider2 {
   private final AtomicInteger decodingIndex = new AtomicInteger(GalleryPageView.INVALID_INDEX);
 
   public ArchiveGalleryProvider(Context context, Uri uri) {
+    this(context, uri, -1L);
+  }
+
+  public ArchiveGalleryProvider(Context context, Uri uri, long galleryId) {
     file = UniFile.fromUri(context, uri);
+    this.galleryId = galleryId;
+    int savedStartPage = Settings.getArchiveReadingProgress(galleryId);
+    int savedPageCount = Settings.getArchivePageCount(galleryId);
+    startPage = savedPageCount > 0
+        ? Math.min(savedStartPage, savedPageCount - 1)
+        : savedStartPage;
   }
 
   @Override
@@ -97,6 +111,27 @@ public class ArchiveGalleryProvider extends GalleryProvider2 {
   @Override
   public int size() {
     return size;
+  }
+
+  @Override
+  public int getStartPage() {
+    synchronized (startPageLock) {
+      return startPage;
+    }
+  }
+
+  @Override
+  public void putStartPage(int page) {
+    if (galleryId < 0 || page < 0) {
+      return;
+    }
+    synchronized (startPageLock) {
+      if (page == startPage) {
+        return;
+      }
+      startPage = page;
+      Settings.putArchiveReadingProgress(galleryId, page);
+    }
   }
 
   @Override
@@ -165,6 +200,9 @@ public class ArchiveGalleryProvider extends GalleryProvider2 {
         }
       }
       if (uraf == null) {
+        synchronized (startPageLock) {
+          Settings.putArchivePageCount(galleryId, 0);
+        }
         size = STATE_ERROR;
         error = GetText.getString(R.string.error_reading_failed);
         notifyDataChanged();
@@ -178,6 +216,9 @@ public class ArchiveGalleryProvider extends GalleryProvider2 {
         e.printStackTrace();
       }
       if (archive == null) {
+        synchronized (startPageLock) {
+          Settings.putArchivePageCount(galleryId, 0);
+        }
         size = STATE_ERROR;
         error = GetText.getString(R.string.error_invalid_archive);
         notifyDataChanged();
@@ -188,7 +229,20 @@ public class ArchiveGalleryProvider extends GalleryProvider2 {
       Collections.sort(entries, naturalComparator);
 
       // Update size and notify changed
-      size = entries.size();
+      int archiveSize = entries.size();
+      synchronized (startPageLock) {
+        if (archiveSize == 0) {
+          if (startPage != 0) {
+            startPage = 0;
+            Settings.putArchiveReadingProgress(galleryId, 0);
+          }
+        } else if (startPage >= archiveSize) {
+          startPage = archiveSize - 1;
+          Settings.putArchiveReadingProgress(galleryId, startPage);
+        }
+        Settings.putArchivePageCount(galleryId, archiveSize);
+      }
+      size = archiveSize;
       notifyDataChanged();
 
       while (!Thread.currentThread().isInterrupted()) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/GalleryActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/GalleryActivity.java
@@ -70,6 +70,7 @@ import com.hippo.ehviewer.AppConfig;
 import com.hippo.ehviewer.R;
 import com.hippo.ehviewer.Settings;
 import com.hippo.ehviewer.client.data.GalleryInfo;
+import com.hippo.ehviewer.dao.DownloadInfo;
 import com.hippo.ehviewer.event.GalleryActivityEvent;
 import com.hippo.ehviewer.gallery.ArchiveGalleryProvider;
 import com.hippo.ehviewer.gallery.DirGalleryProvider;
@@ -228,6 +229,14 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
         }
     };
 
+    private long getImportedArchiveGid() {
+        if (mGalleryInfo instanceof DownloadInfo downloadInfo && mUri != null &&
+                mUri.toString().equals(downloadInfo.archiveUri)) {
+            return downloadInfo.gid;
+        }
+        return -1L;
+    }
+
     @Override
     protected int getThemeResId(int theme) {
         switch (theme) {
@@ -257,7 +266,7 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
         } else if (Intent.ACTION_VIEW.equals(mAction)) {
             if (mUri != null) {
                 // Only support zip now
-                mGalleryProvider = new ArchiveGalleryProvider(this, mUri);
+                mGalleryProvider = new ArchiveGalleryProvider(this, mUri, getImportedArchiveGid());
             }
         }
     }

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/download/DownloadsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/download/DownloadsScene.java
@@ -24,6 +24,7 @@ import static com.hippo.util.FileUtils.getFileName;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -36,6 +37,7 @@ import android.graphics.drawable.NinePatchDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Process;
 import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.Display;
@@ -59,6 +61,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.lifecycle.Lifecycle;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
@@ -105,8 +108,11 @@ import com.hippo.ehviewer.widget.MyEasyRecyclerView;
 import com.hippo.ehviewer.widget.SearchBar;
 import com.hippo.lib.yorozuya.AssertUtils;
 import com.hippo.lib.yorozuya.ObjectUtils;
+import com.hippo.lib.yorozuya.SimpleHandler;
 import com.hippo.lib.yorozuya.ViewUtils;
 import com.hippo.lib.yorozuya.collect.LongList;
+import com.hippo.lib.yorozuya.thread.PriorityThreadFactory;
+import com.hippo.lib.yorozuya.thread.SerialThreadExecutor;
 import com.hippo.ripple.Ripple;
 import com.hippo.unifile.UniFile;
 import com.hippo.util.DrawableManager;
@@ -123,14 +129,20 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Executor;
 
 public class DownloadsScene extends ToolbarScene
         implements DownloadManager.DownloadInfoListener, DownloadSearchCallback,
@@ -139,6 +151,12 @@ public class DownloadsScene extends ToolbarScene
         FabLayout.OnClickFabListener, FabLayout.OnExpandListener, FastScroller.OnDragHandlerListener, SearchBar.Helper, SearchBarMover.Helper, SearchBar.OnStateChangeListener, DownloadAdapter.DownloadAdapterCallback {
 
     private static final String TAG = DownloadsScene.class.getSimpleName();
+    private static final int MAX_ARCHIVE_IMPORT_COUNT = 50;
+
+    private static final Executor ARCHIVE_IMPORT_EXECUTOR = new SerialThreadExecutor(
+            3000L, new LinkedList<>(),
+            new PriorityThreadFactory("ArchiveImport", Process.THREAD_PRIORITY_BACKGROUND));
+    private static long sLastLocalGalleryId;
 
     public static final String KEY_GID = "gid";
 
@@ -239,7 +257,7 @@ public class DownloadsScene extends ToolbarScene
     @NonNull
     private final ActivityResultLauncher<Intent> filePickerLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
-            this::handleSelectedFile
+            this::handleSelectedFiles
     );
 
     @Override
@@ -782,10 +800,10 @@ public class DownloadsScene extends ToolbarScene
                         .setMessage(R.string.reset_reading_progress_message)
                         .setNegativeButton(android.R.string.cancel, null)
                         .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                            resetReadingProgressInUi();
                             if (mDownloadManager != null) {
                                 mDownloadManager.resetAllReadingProgress();
                             }
+                            resetReadingProgressInUi();
                         }).show();
                 return true;
             }
@@ -1003,6 +1021,7 @@ public class DownloadsScene extends ToolbarScene
                 }
                 intent.setAction(Intent.ACTION_VIEW);
                 intent.setData(archiveUri);
+                intent.putExtra(GalleryActivity.KEY_GALLERY_INFO, downloadInfo);
             } else {
                 // This is a normal download, use ACTION_EH
                 intent.setAction(GalleryActivity.ACTION_EH);
@@ -1262,8 +1281,19 @@ public class DownloadsScene extends ToolbarScene
     @SuppressLint("NotifyDataSetChanged")
     @Override
     public void onReload() {
+        if (mDownloadManager != null) {
+            Iterator<Long> iterator = mSpiderInfoMap.keySet().iterator();
+            while (iterator.hasNext()) {
+                if (!mDownloadManager.containDownloadInfo(iterator.next())) {
+                    iterator.remove();
+                }
+            }
+        }
         if (mAdapter != null) {
             mAdapter.notifyDataSetChanged();
+        }
+        if (downloadLabelDraw != null && mViewTransition != null) {
+            downloadLabelDraw.updateDownloadLabels();
         }
         updateView();
     }
@@ -1288,11 +1318,15 @@ public class DownloadsScene extends ToolbarScene
 
     @Override
     public void onRemove(@NonNull DownloadInfo info, @NonNull List<DownloadInfo> list, int position) {
+        mSpiderInfoMap.remove(info.gid);
         if (mList != list) {
             return;
         }
         if (mAdapter != null) {
             mAdapter.notifyItemRemoved(listIndexInPage(position));
+        }
+        if (downloadLabelDraw != null && mViewTransition != null) {
+            downloadLabelDraw.updateDownloadLabels();
         }
         updateView();
     }
@@ -1556,17 +1590,9 @@ public class DownloadsScene extends ToolbarScene
             if (data != null) {
                 GalleryInfo info = data.getParcelableExtra("info");
 
-                // Check if this is an imported archive - skip SpiderInfo processing
-                boolean isImportedArchive = false;
-                if (info instanceof DownloadInfo downloadInfo) {
-                    isImportedArchive = downloadInfo.archiveUri != null &&
-                            downloadInfo.archiveUri.startsWith("content://");
-                }
-
-                if (!isImportedArchive && info != null) {
-                    // Only process SpiderInfo for regular downloads, not imported archives
+                if (info != null) {
                     mSpiderInfoMap.remove(info.gid);
-                    SpiderInfo spiderInfo = getSpiderInfo(info);
+                    SpiderInfo spiderInfo = getReadingProgressInfo(info);
                     if (spiderInfo != null) {
                         mSpiderInfoMap.put(info.gid, spiderInfo);
                     }
@@ -1606,16 +1632,30 @@ public class DownloadsScene extends ToolbarScene
         }
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     private void queryUnreadSpiderInfo() {
         if (mList == null) {
             return;
         }
         List<DownloadInfo> requestList = new ArrayList<>();
+        boolean hasImportedArchive = false;
         for (int i = 0; i < mList.size(); i++) {
             DownloadInfo info = mList.get(i);
+            if (isImportedArchive(info)) {
+                hasImportedArchive = true;
+                mSpiderInfoMap.remove(info.gid);
+                SpiderInfo spiderInfo = getReadingProgressInfo(info);
+                if (spiderInfo != null) {
+                    mSpiderInfoMap.put(info.gid, spiderInfo);
+                }
+                continue;
+            }
             if (!mSpiderInfoMap.containsKey(info.gid) || mSpiderInfoMap.get(info.gid) == null) {
                 requestList.add(info);
             }
+        }
+        if (hasImportedArchive && mAdapter != null) {
+            mAdapter.notifyDataSetChanged();
         }
         DownloadSpiderInfoExecutor executor = new DownloadSpiderInfoExecutor(requestList, this::spiderInfoResultCallBack);
         executor.execute();
@@ -1674,6 +1714,7 @@ public class DownloadsScene extends ToolbarScene
                 "application/x-cbz",
                 "application/x-cbr"
         });
+        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         // CRITICAL: Add flags to enable persistent URI permissions
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
@@ -1689,125 +1730,261 @@ public class DownloadsScene extends ToolbarScene
         }
     }
 
-    private void handleSelectedFile(ActivityResult result) {
+    private void handleSelectedFiles(ActivityResult result) {
         if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
             return;
         }
 
-        Uri uri = result.getData().getData();
-        if (uri == null) {
+        Intent data = result.getData();
+        List<Uri> selectedUris = collectSelectedUris(data);
+        if (selectedUris.isEmpty()) {
             return;
         }
 
         Context context = getEHContext();
-        if (context == null) {
+        DownloadManager downloadManager = mDownloadManager;
+        if (context == null || downloadManager == null) {
+            return;
+        }
+        if (selectedUris.size() > MAX_ARCHIVE_IMPORT_COUNT) {
+            Toast.makeText(context, context.getString(R.string.import_archive_too_many,
+                    selectedUris.size(), MAX_ARCHIVE_IMPORT_COUNT), Toast.LENGTH_LONG).show();
             return;
         }
 
-        // CRITICAL: Request persistent URI permission IMMEDIATELY when file is selected
-        // This is the key to solving the permission loss issue after app restart
-        try {
-            context.getContentResolver().takePersistableUriPermission(uri,
-                    Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            Log.d(TAG, "Successfully obtained persistent URI permission for: " + uri);
-        } catch (SecurityException e) {
-            Log.e(TAG, "Failed to obtain persistent URI permission for: " + uri, e);
+        int takeFlags = data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        if (takeFlags == 0) {
+            takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        }
+
+        List<Uri> permittedUris = new ArrayList<>(selectedUris.size());
+        int permissionFailureCount = 0;
+        for (Uri uri : selectedUris) {
+            try {
+                context.getContentResolver().takePersistableUriPermission(uri, takeFlags);
+                permittedUris.add(uri);
+                Log.d(TAG, "Successfully obtained persistent URI permission for: " + uri);
+            } catch (SecurityException e) {
+                permissionFailureCount++;
+                Log.e(TAG, "Failed to obtain persistent URI permission for: " + uri, e);
+            } catch (Exception e) {
+                permissionFailureCount++;
+                Log.e(TAG, "Unexpected error when obtaining URI permission for: " + uri, e);
+            }
+        }
+
+        if (permittedUris.isEmpty()) {
             Toast.makeText(context, R.string.archive_permission_lost, Toast.LENGTH_LONG).show();
             return;
-        } catch (Exception e) {
-            Log.e(TAG, "Unexpected error when obtaining URI permission for: " + uri, e);
-            Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show();
-            return;
         }
 
-        // Show processing dialog
         Toast.makeText(context, R.string.import_archive_processing, Toast.LENGTH_LONG).show();
 
-        // Process the archive file in background
-        new Thread(() -> processArchiveFile(uri)).start();
+        Context applicationContext = context.getApplicationContext();
+        String targetLabel = mLabel;
+        int selectedCount = selectedUris.size();
+        int finalPermissionFailureCount = permissionFailureCount;
+        WeakReference<DownloadsScene> sceneReference = new WeakReference<>(this);
+        try {
+            ARCHIVE_IMPORT_EXECUTOR.execute(() -> DownloadsScene.processArchiveFiles(applicationContext,
+                    downloadManager, permittedUris, targetLabel, selectedCount,
+                    finalPermissionFailureCount, sceneReference));
+        } catch (RuntimeException e) {
+            for (Uri uri : permittedUris) {
+                downloadManager.releaseArchiveUriPermissionIfUnused(uri.toString());
+            }
+            Log.e(TAG, "Failed to schedule archive import", e);
+            Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show();
+        }
     }
 
-    private void processArchiveFile(Uri uri) {
-        Context context = getEHContext();
-        if (context == null) {
-            return;
+    private static List<Uri> collectSelectedUris(Intent data) {
+        Set<Uri> selectedUris = new LinkedHashSet<>();
+        Uri singleUri = data.getData();
+        if (singleUri != null) {
+            selectedUris.add(singleUri);
         }
+        ClipData clipData = data.getClipData();
+        if (clipData != null) {
+            for (int i = 0; i < clipData.getItemCount(); i++) {
+                Uri uri = clipData.getItemAt(i).getUri();
+                if (uri != null) {
+                    selectedUris.add(uri);
+                }
+            }
+        }
+        return new ArrayList<>(selectedUris);
+    }
 
-        try {
-            // Verify URI accessibility (permission should already be granted)
+    private static void processArchiveFiles(Context context, DownloadManager downloadManager,
+                                            List<Uri> uris, @Nullable String targetLabel,
+                                            int selectedCount, int permissionFailureCount,
+                                            WeakReference<DownloadsScene> sceneReference) {
+        List<PendingArchiveImport> pendingImports = new ArrayList<>(uris.size());
+        int invalidFormatCount = 0;
+        int failedCount = permissionFailureCount;
+
+        for (Uri uri : uris) {
             try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
                 if (inputStream == null) {
-                    runOnUiThread(() ->
-                            Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show()
-                    );
-                    return;
+                    failedCount++;
+                    continue;
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Cannot access file even with persistent permission", e);
-                runOnUiThread(() ->
-                        Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show()
-                );
+                failedCount++;
+                continue;
+            }
+
+            try {
+                String fileName = getFileName(context, uri);
+                if (!isValidArchiveFormat(fileName)) {
+                    invalidFormatCount++;
+                    continue;
+                }
+
+                pendingImports.add(new PendingArchiveImport(uri, fileName));
+            } catch (Exception e) {
+                failedCount++;
+                Log.e(TAG, "Failed to process archive file: " + uri, e);
+            }
+        }
+
+        postArchiveImportResult(context, downloadManager, sceneReference, selectedCount,
+                uris, pendingImports, targetLabel, invalidFormatCount, failedCount);
+    }
+
+    private static Set<String> getImportedArchiveUriSnapshot(DownloadManager downloadManager) {
+        Set<String> snapshot = new HashSet<>();
+        for (DownloadInfo info : downloadManager.getAllDownloadInfoList()) {
+            if (info.archiveUri != null) {
+                snapshot.add(info.archiveUri);
+            }
+        }
+        return snapshot;
+    }
+
+    private static void postArchiveImportResult(Context context,
+                                                DownloadManager downloadManager,
+                                                WeakReference<DownloadsScene> sceneReference,
+                                                int selectedCount,
+                                                List<Uri> permissionUris,
+                                                List<PendingArchiveImport> pendingImports,
+                                                @Nullable String targetLabel,
+                                                int invalidFormatCount, int failedCount) {
+        SimpleHandler.getInstance().post(() -> {
+            int alreadyImportedCount = 0;
+            int committedFailedCount = failedCount;
+            List<DownloadInfo> downloadList = new ArrayList<>(pendingImports.size());
+            Set<String> importedArchiveUris;
+
+            if (targetLabel != null && !downloadManager.containLabel(targetLabel)) {
+                committedFailedCount += pendingImports.size();
+                importedArchiveUris = null;
+                Log.w(TAG, "Archive import target label no longer exists: " + targetLabel);
+            } else {
+                try {
+                    importedArchiveUris = getImportedArchiveUriSnapshot(downloadManager);
+                } catch (RuntimeException e) {
+                    committedFailedCount += pendingImports.size();
+                    importedArchiveUris = null;
+                    Log.e(TAG, "Failed to create imported archive URI snapshot", e);
+                }
+            }
+
+            if (importedArchiveUris != null) {
+                for (PendingArchiveImport pendingImport : pendingImports) {
+                    String archiveUri = pendingImport.uri.toString();
+                    if (!importedArchiveUris.add(archiveUri)) {
+                        alreadyImportedCount++;
+                        continue;
+                    }
+                    try {
+                        downloadList.add(createArchiveDownloadInfo(downloadManager,
+                                pendingImport.uri, pendingImport.fileName, targetLabel));
+                    } catch (RuntimeException e) {
+                        committedFailedCount++;
+                        Log.e(TAG, "Failed to prepare imported archive: " + archiveUri, e);
+                    }
+                }
+
+                if (!downloadList.isEmpty()) {
+                    int preparedCount = downloadList.size();
+                    try {
+                        downloadList = downloadManager.addDownload(downloadList);
+                        committedFailedCount += preparedCount - downloadList.size();
+                    } catch (RuntimeException e) {
+                        committedFailedCount += downloadList.size();
+                        downloadList.clear();
+                        Log.e(TAG, "Failed to commit imported archives", e);
+                    }
+                }
+            }
+
+            for (Uri uri : permissionUris) {
+                downloadManager.releaseArchiveUriPermissionIfUnused(uri.toString());
+            }
+
+            int importedCount = downloadList.size();
+            DownloadsScene scene = sceneReference.get();
+            if (scene == null || !scene.isAdded() || scene.mViewTransition == null ||
+                    scene.mDownloadManager != downloadManager || scene.getView() == null) {
+                return;
+            }
+            MainActivity activity = scene.getActivity2();
+            if (activity == null || !activity.getLifecycle().getCurrentState()
+                    .isAtLeast(Lifecycle.State.STARTED) ||
+                    scene.getStackIndex() != activity.getSceneCount() - 1) {
                 return;
             }
 
-            // Get file name
-            String fileName = getFileName(context, uri);
-            if (fileName == null) {
-                fileName = "imported_archive_" + System.currentTimeMillis();
-            }
+            showArchiveImportResult(context, selectedCount, importedCount,
+                    invalidFormatCount, alreadyImportedCount, committedFailedCount);
+            scene.updateForLabel();
+            scene.updateView();
+        });
+    }
 
-            // Validate file format
-            if (!isValidArchiveFormat(fileName)) {
-                runOnUiThread(() ->
-                        Toast.makeText(context, R.string.import_archive_invalid_format, Toast.LENGTH_SHORT).show()
-                );
-                return;
-            }
+    private static final class PendingArchiveImport {
+        private final Uri uri;
+        private final String fileName;
 
-            // Create DownloadInfo for the archive
-            DownloadInfo downloadInfo = createArchiveDownloadInfo(context, uri, fileName);
-            if (downloadInfo == null) {
-                runOnUiThread(() ->
-                        Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show()
-                );
-                return;
-            }
-
-            // Check if already imported
-            if (mDownloadManager != null && mDownloadManager.containDownloadInfo(downloadInfo.gid)) {
-                runOnUiThread(() ->
-                        Toast.makeText(context, R.string.import_archive_already_imported, Toast.LENGTH_SHORT).show()
-                );
-                return;
-            }
-
-            // Add to download manager
-            if (mDownloadManager != null) {
-                List<DownloadInfo> downloadList = new ArrayList<>();
-                downloadList.add(downloadInfo);
-                mDownloadManager.addDownload(downloadList);
-                runOnUiThread(() -> {
-                    Toast.makeText(context, R.string.import_archive_success, Toast.LENGTH_SHORT).show();
-                    updateForLabel();
-                    updateView();
-                });
-            }
-
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to process archive file", e);
-            runOnUiThread(() ->
-                    Toast.makeText(context, R.string.import_archive_failed, Toast.LENGTH_SHORT).show()
-            );
+        private PendingArchiveImport(Uri uri, String fileName) {
+            this.uri = uri;
+            this.fileName = fileName;
         }
     }
 
-    private boolean isValidArchiveFormat(String fileName) {
-        if (fileName == null) return false;
-        String lowerName = fileName.toLowerCase();
+    private static boolean isImportedArchive(DownloadInfo info) {
+        return info.archiveUri != null && info.archiveUri.startsWith("content://");
+    }
+
+    private static boolean isValidArchiveFormat(@Nullable String fileName) {
+        if (fileName == null) {
+            return false;
+        }
+        String lowerName = fileName.toLowerCase(Locale.ROOT);
         return lowerName.endsWith(".zip") || lowerName.endsWith(".rar") ||
                 lowerName.endsWith(".cbz") || lowerName.endsWith(".cbr");
     }
 
+    @Nullable
+    private static SpiderInfo getReadingProgressInfo(GalleryInfo info) {
+        if (info instanceof DownloadInfo downloadInfo && isImportedArchive(downloadInfo)) {
+            int startPage = Settings.getArchiveReadingProgress(downloadInfo.gid);
+            int pageCount = Settings.getArchivePageCount(downloadInfo.gid);
+            if (startPage == 0 && pageCount == 0) {
+                return null;
+            }
+            SpiderInfo spiderInfo = new SpiderInfo();
+            spiderInfo.gid = downloadInfo.gid;
+            spiderInfo.token = downloadInfo.token;
+            spiderInfo.startPage = startPage;
+            spiderInfo.pages = pageCount;
+            return spiderInfo;
+        }
+        return getSpiderInfo(info);
+    }
 
     public void runOnUiThread(Runnable runnable) {
         Activity activity = getActivity2();
@@ -1816,33 +1993,61 @@ public class DownloadsScene extends ToolbarScene
         }
     }
 
-    private DownloadInfo createArchiveDownloadInfo(Context context, Uri uri, String fileName) {
-        try {
-            DownloadInfo downloadInfo = new DownloadInfo();
-            downloadInfo.gid = System.currentTimeMillis(); // Use timestamp as unique ID
-            downloadInfo.token = "";
-            downloadInfo.title = fileName.replaceAll("\\.[^.]*$", ""); // Remove extension
-            downloadInfo.titleJpn = null;
-            downloadInfo.thumb = null; // No thumbnail for imported archives
-            downloadInfo.category = EhUtils.UNKNOWN; // Keep as UNKNOWN, will be handled in display logic
-            downloadInfo.posted = null;
-            downloadInfo.uploader = "Local Archive";
-            downloadInfo.rating = -1.0f; // Keep default rating to not affect other downloads
-            downloadInfo.state = DownloadInfo.STATE_FINISH;
-            downloadInfo.legacy = 0;
-            downloadInfo.time = System.currentTimeMillis();
-            downloadInfo.label = null;
-            downloadInfo.total = 0; // Will be set by archive provider
-            downloadInfo.finished = 0;
-
-            // Store the URI in the archiveUri field - this is the key identifier
-            downloadInfo.archiveUri = uri.toString();
-
-            return downloadInfo;
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to create DownloadInfo", e);
-            return null;
+    private static void showArchiveImportResult(Context context, int selectedCount,
+                                                int importedCount, int invalidFormatCount,
+                                                int alreadyImportedCount, int failedCount) {
+        if (importedCount == selectedCount) {
+            Toast.makeText(context, R.string.import_archive_success, Toast.LENGTH_SHORT).show();
+        } else if (importedCount == 0) {
+            int message;
+            if (invalidFormatCount == selectedCount) {
+                message = R.string.import_archive_invalid_format;
+            } else if (alreadyImportedCount == selectedCount) {
+                message = R.string.import_archive_already_imported;
+            } else {
+                message = R.string.import_archive_failed;
+            }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
+        } else {
+            int skippedCount = invalidFormatCount + alreadyImportedCount + failedCount;
+            String message = context.getString(R.string.import_archive_success) + ": " +
+                    importedCount + "/" + selectedCount + "\n" +
+                    context.getString(R.string.import_archive_failed) + ": " +
+                    skippedCount + "/" + selectedCount;
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show();
         }
+    }
+
+    private static DownloadInfo createArchiveDownloadInfo(DownloadManager downloadManager,
+                                                          Uri uri, String fileName,
+                                                          @Nullable String label) {
+        DownloadInfo downloadInfo = new DownloadInfo();
+        downloadInfo.gid = nextLocalGalleryId(downloadManager);
+        downloadInfo.token = "";
+        downloadInfo.title = fileName.replaceAll("\\.[^.]*$", "");
+        downloadInfo.titleJpn = null;
+        downloadInfo.thumb = null;
+        downloadInfo.category = EhUtils.UNKNOWN;
+        downloadInfo.posted = null;
+        downloadInfo.uploader = "Local Archive";
+        downloadInfo.rating = -1.0f;
+        downloadInfo.state = DownloadInfo.STATE_FINISH;
+        downloadInfo.legacy = 0;
+        downloadInfo.time = System.currentTimeMillis();
+        downloadInfo.label = label;
+        downloadInfo.total = 0;
+        downloadInfo.finished = 0;
+        downloadInfo.archiveUri = uri.toString();
+        return downloadInfo;
+    }
+
+    private static synchronized long nextLocalGalleryId(DownloadManager downloadManager) {
+        long galleryId = Math.max(System.currentTimeMillis(), sLastLocalGalleryId + 1L);
+        while (downloadManager.containDownloadInfo(galleryId)) {
+            galleryId++;
+        }
+        sLastLocalGalleryId = galleryId;
+        return galleryId;
     }
 
     private class DeleteDialogHelper implements DialogInterface.OnClickListener {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/download/part/DownloadAdapter.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/download/part/DownloadAdapter.java
@@ -203,8 +203,10 @@ public class DownloadAdapter extends RecyclerView.Adapter<DownloadAdapter.Downlo
             }
 
             SpiderInfo spiderInfo = mCallback.getSpiderInfoMap().get(info.gid);
-
-            if (spiderInfo != null) {
+            if (info.archiveUri != null && info.archiveUri.startsWith("content://")) {
+                holder.readProgress.setText(spiderInfo == null ? null :
+                        formatArchiveReadingProgress(spiderInfo.startPage, spiderInfo.pages));
+            } else if (spiderInfo != null) {
                 int startPage = spiderInfo.startPage + 1;
                 String readText = startPage + "/" + spiderInfo.pages;
                 holder.readProgress.setText(readText);
@@ -233,6 +235,15 @@ public class DownloadAdapter extends RecyclerView.Adapter<DownloadAdapter.Downlo
         } catch (Exception e) {
             Analytics.recordException(e);
         }
+    }
+
+    private static String formatArchiveReadingProgress(int startPage, int pageCount) {
+        int normalizedStartPage = Math.max(startPage, 0);
+        if (pageCount <= 0) {
+            return normalizedStartPage > 0 ? (normalizedStartPage + 1L) + "/?" : null;
+        }
+        int displayPage = Math.min(normalizedStartPage, pageCount - 1) + 1;
+        return displayPage + "/" + pageCount;
     }
 
     @Override

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -980,6 +980,7 @@
     <string name="import_archive_invalid_format">不支持的压缩包格式</string>
     <string name="import_archive_already_imported">压缩包已导入</string>
     <string name="import_archive_success">压缩包导入成功</string>
+    <string name="import_archive_too_many">已选择 %1$d 个压缩包，单次最多导入 %2$d 个。</string>
     <string name="archive_not_accessible">压缩包文件无法访问</string>
     <string name="imported_archive_info_title">本地导入信息</string>
     <string name="imported_archive_info_message">这是从本地存储中导入的项目</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1068,6 +1068,7 @@
     <string name="import_archive_invalid_format">Unsupported archive format</string>
     <string name="import_archive_already_imported">Archive already imported</string>
     <string name="import_archive_success">Archive imported successfully</string>
+    <string name="import_archive_too_many">Selected %1$d archives; you can import up to %2$d at a time.</string>
     <string name="archive_not_accessible">Archive file is not accessible</string>
     <string name="imported_archive_info_title">Local Import Info</string>
     <string name="imported_archive_info_message">This is an item imported from local storage</string>


### PR DESCRIPTION
## 变更内容

- 保存本地压缩包的阅读进度，并在下载列表显示。
- 支持单次选择并导入最多 50 个 ZIP、RAR、CBZ、CBR 文件。
- 从下载标签中发起导入时，将压缩包添加到当前标签。
- 删除或重置本地导入记录时同步清理阅读进度。
- 完善批量导入、删除及页面切换时的状态一致性处理。

## 相关 Issue

- Closes #2274
  - 解决本地压缩包重新打开后总是从第一页开始的问题。
  - 保存上次阅读位置，并在下载列表显示阅读进度。

- Refs #2248
  - 解决第 1 项：文件选择器无法多选压缩包的问题。
  - 解决第 2 项：压缩包始终导入默认标签、无法导入当前标签的问题。
  - 第 3 项“删除记录时同时删除原始压缩包”不在本 PR 范围内。

- Refs #2308
  - 解决本地压缩包只能逐个选择、无法批量导入的问题。