### PR TITLE
feat: 缩略图大小新增自定义档位

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/Settings.java
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.java
@@ -23,6 +23,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -42,6 +43,7 @@ import com.hippo.unifile.UniFile;
 import com.hippo.util.ExceptionUtils;
 import com.hippo.lib.yorozuya.AssertUtils;
 import com.hippo.lib.yorozuya.FileUtils;
+import com.hippo.lib.yorozuya.LayoutUtils;
 import com.hippo.lib.yorozuya.MathUtils;
 import com.hippo.lib.yorozuya.NumberUtils;
 
@@ -432,20 +434,29 @@ public class Settings {
     public static final String KEY_THUMB_SIZE = "thumb_size";
     private static final int DEFAULT_THUMB_SIZE = 1;
 
+    public static final String KEY_THUMB_SIZE_CUSTOM = "thumb_size_custom";
+    public static final int DEFAULT_THUMB_SIZE_CUSTOM = 200;
+    private static final int MIN_THUMB_SIZE_CUSTOM = 40;
+
     public static int getThumbSize() {
         return getIntFromStr(KEY_THUMB_SIZE, DEFAULT_THUMB_SIZE);
     }
 
-    @DimenRes
-    public static int getThumbSizeResId() {
+    public static int getThumbSizeCustom() {
+        return Math.max(getInt(KEY_THUMB_SIZE_CUSTOM, DEFAULT_THUMB_SIZE_CUSTOM), MIN_THUMB_SIZE_CUSTOM);
+    }
+
+    public static int getThumbSizePx(Resources resources) {
         switch (getThumbSize()) {
             case 0:
-                return R.dimen.gallery_grid_column_width_large;
+                return resources.getDimensionPixelOffset(R.dimen.gallery_grid_column_width_large);
             default:
             case 1:
-                return R.dimen.gallery_grid_column_width_middle;
+                return resources.getDimensionPixelOffset(R.dimen.gallery_grid_column_width_middle);
             case 2:
-                return R.dimen.gallery_grid_column_width_small;
+                return resources.getDimensionPixelOffset(R.dimen.gallery_grid_column_width_small);
+            case 3:
+                return LayoutUtils.dp2pix(sContext, getThumbSizeCustom());
         }
     }
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/fragment/EhFragment.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/fragment/EhFragment.java
@@ -33,6 +33,10 @@ import com.hippo.ehviewer.client.EhTagDatabase;
 public class EhFragment extends BasePreferenceFragmentCompat
         implements Preference.OnPreferenceChangeListener {
 
+    private static final int THUMB_SIZE_CUSTOM = 3;
+
+    private Preference mThumbSizeCustom;
+
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         addPreferencesFromResource(R.xml.eh_settings);
@@ -44,6 +48,7 @@ public class EhFragment extends BasePreferenceFragmentCompat
         Preference listMode = findPreference(Settings.KEY_LIST_MODE);
         Preference detailSize = findPreference(Settings.KEY_DETAIL_SIZE);
         Preference thumbSize = findPreference(Settings.KEY_THUMB_SIZE);
+        mThumbSizeCustom = findPreference(Settings.KEY_THUMB_SIZE_CUSTOM);
         Preference historyInfoSize = findPreference(Settings.KEY_HISTORY_INFO_SIZE);
         Preference showTagTranslations = findPreference(Settings.KEY_SHOW_TAG_TRANSLATIONS);
         Preference showGalleryComment = findPreference(Settings.KEY_SHOW_GALLERY_COMMENT);
@@ -65,6 +70,11 @@ public class EhFragment extends BasePreferenceFragmentCompat
         historyInfoSize.setOnPreferenceChangeListener(this);
         showTagTranslations.setOnPreferenceChangeListener(this);
         showGalleryComment.setOnPreferenceChangeListener(this);
+
+        if (mThumbSizeCustom != null) {
+            mThumbSizeCustom.setOnPreferenceChangeListener(this);
+            updateThumbSizeCustomState(Settings.getThumbSize() == THUMB_SIZE_CUSTOM);
+        }
 
         if (!EhTagDatabase.isPossible(getActivity())) {
             getPreferenceScreen().removePreference(showTagTranslations);
@@ -91,6 +101,13 @@ public class EhFragment extends BasePreferenceFragmentCompat
             getActivity().setResult(Activity.RESULT_OK);
             return true;
         } else if (Settings.KEY_THUMB_SIZE.equals(key)) {
+            updateThumbSizeCustomState(Integer.toString(THUMB_SIZE_CUSTOM).equals(newValue.toString()));
+            getActivity().setResult(Activity.RESULT_OK);
+            return true;
+        } else if (Settings.KEY_THUMB_SIZE_CUSTOM.equals(key)) {
+            if (newValue instanceof Integer) {
+                updateThumbSizeCustomSummary((Integer) newValue);
+            }
             getActivity().setResult(Activity.RESULT_OK);
             return true;
         } else if (Settings.KEY_SHOW_TAG_TRANSLATIONS.equals(key)) {
@@ -122,6 +139,19 @@ public class EhFragment extends BasePreferenceFragmentCompat
             return true;
         }
         return true;
+    }
+
+    private void updateThumbSizeCustomState(boolean enabled) {
+        if (mThumbSizeCustom != null) {
+            mThumbSizeCustom.setEnabled(enabled);
+            updateThumbSizeCustomSummary(Settings.getThumbSizeCustom());
+        }
+    }
+
+    private void updateThumbSizeCustomSummary(int value) {
+        if (mThumbSizeCustom != null) {
+            mThumbSizeCustom.setSummary(getString(R.string.settings_eh_thumb_size_custom_size_summary, value));
+        }
     }
 
     private String getSystemThemeSummary() {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
@@ -148,7 +148,7 @@ public class GalleryPreviewsScene extends ToolbarScene implements EasyRecyclerVi
 
         mAdapter = new GalleryPreviewAdapter();
         mRecyclerView.setAdapter(mAdapter);
-        int columnWidth = resources.getDimensionPixelOffset(Settings.getThumbSizeResId());
+        int columnWidth = Settings.getThumbSizePx(resources);
         AutoGridLayoutManager layoutManager = new AutoGridLayoutManager(context, columnWidth);
         layoutManager.setStrategy(AutoGridLayoutManager.STRATEGY_SUITABLE_SIZE);
         mRecyclerView.setLayoutManager(layoutManager);

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -1191,7 +1191,7 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
         PreviewSet previewSet = gd.previewSet;
 
 
-        int columnWidth = resources.getDimensionPixelOffset(Settings.getThumbSizeResId());
+        int columnWidth = Settings.getThumbSizePx(resources);
         mGridLayout.setColumnSize(columnWidth);
         mGridLayout.setStrategy(SimpleGridAutoSpanLayout.STRATEGY_SUITABLE_SIZE);
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryAdapter.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryAdapter.java
@@ -142,7 +142,7 @@ abstract class GalleryAdapter extends RecyclerView.Adapter<GalleryHolder> {
                 break;
             }
             case GalleryAdapter.TYPE_GRID: {
-                int columnWidth = mResources.getDimensionPixelOffset(Settings.getThumbSizeResId());
+                int columnWidth = Settings.getThumbSizePx(mResources);
                 mLayoutManager.setColumnSize(columnWidth);
                 mLayoutManager.setStrategy(AutoStaggeredGridLayoutManager.STRATEGY_SUITABLE_SIZE);
                 if (null != mListDecoration) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryAdapterNew.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryAdapterNew.java
@@ -150,7 +150,7 @@ abstract class GalleryAdapterNew extends RecyclerView.Adapter<GalleryAdapterNew.
                 break;
             }
             case GalleryAdapterNew.TYPE_GRID: {
-                int columnWidth = mResources.getDimensionPixelOffset(Settings.getThumbSizeResId());
+                int columnWidth = Settings.getThumbSizePx(mResources);
                 mLayoutManager.setColumnSize(columnWidth);
                 mLayoutManager.setStrategy(AutoStaggeredGridLayoutManager.STRATEGY_SUITABLE_SIZE);
                 if (null != mListDecoration) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -516,6 +516,9 @@
     <string name="settings_eh_thumb_size_large">大</string>
     <string name="settings_eh_thumb_size_middle">中</string>
     <string name="settings_eh_thumb_size_small">小</string>
+    <string name="settings_eh_thumb_size_custom">自定义</string>
+    <string name="settings_eh_thumb_size_custom_size">自定义缩略图大小</string>
+    <string name="settings_eh_thumb_size_custom_size_summary">当前为 %d dp</string>
     <string name="settings_eh_thumb_resolution">缩略图分辨率</string>
     <string name="settings_eh_thumb_resolution_summary">%s，指定分辨率可能使获取缩略图失败</string>
     <string name="settings_eh_thumb_resolution_auto">自动</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -103,12 +103,14 @@
         <item>@string/settings_eh_thumb_size_large</item>
         <item>@string/settings_eh_thumb_size_middle</item>
         <item>@string/settings_eh_thumb_size_small</item>
+        <item>@string/settings_eh_thumb_size_custom</item>
     </string-array>
 
     <string-array name="thumb_size_entry_values" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>2</item>
+        <item>3</item>
     </string-array>
 
     <string-array name="history_info_size_entries" translatable="false">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -604,6 +604,9 @@
     <string name="settings_eh_thumb_size_large">Large</string>
     <string name="settings_eh_thumb_size_middle">Middle</string>
     <string name="settings_eh_thumb_size_small">Small</string>
+    <string name="settings_eh_thumb_size_custom">Custom</string>
+    <string name="settings_eh_thumb_size_custom_size">Custom thumb size</string>
+    <string name="settings_eh_thumb_size_custom_size_summary">Currently %d dp</string>
     <string name="settings_eh_thumb_resolution">Thumb resolution</string>
     <string name="settings_eh_thumb_resolution_summary">Currently %s. Certain resolutions might cause getting thumb failed</string>
     <string name="settings_eh_thumb_resolution_auto">Auto</string>

--- a/app/src/main/res/xml/eh_settings.xml
+++ b/app/src/main/res/xml/eh_settings.xml
@@ -124,6 +124,13 @@
         app:entries="@array/thumb_size_entries"
         app:entryValues="@array/thumb_size_entry_values" />
 
+    <com.hippo.preference.SeekBarPreference
+        android:defaultValue="200"
+        android:key="thumb_size_custom"
+        android:title="@string/settings_eh_thumb_size_custom_size"
+        app:allowDividerAbove="true"
+        app:max="400" />
+
     <com.hippo.preference.ListPreference
         android:defaultValue="100"
         android:key="history_info_size"


### PR DESCRIPTION
# 简述
功能：允许在设置中自定义缩略图的大小，而不是仅仅固定三档
动机：用缩略图快速浏览很方便，就是嫌太小，所以想自定义大小，原来的3档还保留着，也不影响其他功能

# 下面是AI生成的代码细节，本身是很小的功能，检查了一下没什么问题
## 功能说明
在"设置 -> EH -> 缩略图大小"中新增"自定义"档位（原有 大/中/小 三档保持不变）。
选中"自定义"后，下方出现滑动条，可在 40dp–400dp 之间自由调节缩略图列宽

## 实现细节
- `thumb_size` 新增选项值 `3`（自定义），旧值 0/1/2 行为完全不变
- 复用项目现有 `SeekBarPreference`（key：`thumb_size_custom`），仅当选中"自定义"档位时可用
- `Settings.getThumbSizeResId()` 重构为 `Settings.getThumbSizePx(Resources)`：
  固定档位仍读 dimen 资源，自定义档位按 dp 换算像素
- 同步更新 4 处调用点：画廊列表（`GalleryAdapter` / `GalleryAdapterNew`）、
  画廊详情预览网格（`GalleryDetailScene`）、画廊预览页（`GalleryPreviewsScene`）
- 布局沿用 `STRATEGY_SUITABLE_SIZE` 策略，列数随屏幕宽度自动适配
- 滑动条摘要实时显示当前 dp 值

## 兼容性
- 老用户已有设置值不受影响，未知值仍回退到"中"档
- 自定义值最小钳制为 40dp，避免 0 宽度导致布局异常

## 测试
- [x] 编译通过（`assembleAppReleaseDebug`）
- [x] 真机验证：固定三档显示正常；自定义档位拖动滑动条即时生效；
      画廊列表 / 详情页 / 预览页排版均随屏幕宽度自适应