### PR TITLE
在漫画菜单的“阅读方向”里添加左右翻页的“单手模式”，点击左侧和右侧都会翻到下一页

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/Settings.java
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.java
@@ -560,6 +560,20 @@ public class Settings {
         putIntToStr(KEY_READING_DIRECTION, value);
     }
 
+    private static final String KEY_ONE_HAND_MODE = "one_hand_mode";
+    private static final boolean DEFAULT_ONE_HAND_MODE = false;
+
+    public static boolean getOneHandMode() {
+        // 单手模式仅在“从左至右”排版下有效；若方向被其他入口（如设置页）改走，自动视为关闭，
+        // 避免“单手=true + 方向=RTL/T2B”的脏状态导致左右点击都翻错方向
+        return getBoolean(KEY_ONE_HAND_MODE, DEFAULT_ONE_HAND_MODE)
+                && getReadingDirection() == GalleryView.LAYOUT_LEFT_TO_RIGHT;
+    }
+
+    public static void putOneHandMode(boolean value) {
+        putBoolean(KEY_ONE_HAND_MODE, value);
+    }
+
     private static final String KEY_PAGE_SCALING = "page_scaling";
     private static final int DEFAULT_PAGE_SCALING = GalleryView.SCALE_FIT;
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/GalleryActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/GalleryActivity.java
@@ -374,6 +374,7 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
         mGalleryView = new GalleryView.Builder(this, mGalleryAdapter).setListener(this).setLayoutMode(Settings.getReadingDirection()).setScaleMode(Settings.getPageScaling()).setStartPosition(Settings.getStartPosition()).setStartPage(startPage).setBackgroundColor(AttrResources.getAttrColor(this, android.R.attr.colorBackground)).setEdgeColor(AttrResources.getAttrColor(this, R.attr.colorEdgeEffect) & 0xffffff | 0x33000000).setPagerInterval(Settings.getShowPageInterval() ? resources.getDimensionPixelOffset(R.dimen.gallery_pager_interval) : 0).setScrollInterval(Settings.getShowPageInterval() ? resources.getDimensionPixelOffset(R.dimen.gallery_scroll_interval) : 0).setPageMinHeight(resources.getDimensionPixelOffset(R.dimen.gallery_page_min_height)).setPageInfoInterval(resources.getDimensionPixelOffset(R.dimen.gallery_page_info_interval)).setProgressColor(ResourcesUtils.getAttrColor(this, androidx.appcompat.R.attr.colorPrimary)).setProgressSize(resources.getDimensionPixelOffset(R.dimen.gallery_progress_size)).setPageTextColor(AttrResources.getAttrColor(this, android.R.attr.textColorSecondary)).setPageTextSize(resources.getDimensionPixelOffset(R.dimen.gallery_page_text_size)).setPageTextTypeface(Typeface.DEFAULT).setErrorTextColor(resources.getColor(R.color.red_500, null)).setErrorTextSize(resources.getDimensionPixelOffset(R.dimen.gallery_error_text_size)).setDefaultErrorString(resources.getString(R.string.error_unknown)).setEmptyString(resources.getString(R.string.error_empty)).build();
         mGLRootView.setContentPane(mGalleryView);
         mGLRootView.setOnGenericMotionListener(this::onGenericMotion);
+        mGalleryView.setOneHandMode(Settings.getOneHandMode());
         mGalleryProvider.setListener(mGalleryAdapter);
         mGalleryProvider.setGLRoot(mGLRootView);
 
@@ -1177,7 +1178,9 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
             mScreenLightness = mView.findViewById(R.id.screen_lightness);
 
             mScreenRotation.setSelection(Settings.getScreenRotation());
-            mReadingDirection.setSelection(Settings.getReadingDirection());
+            // 菜单阅读方向下拉框含第4项“单手模式”：单手开启时选中第3项，否则按实际排版方向
+            mReadingDirection.setSelection(Settings.getOneHandMode()
+                    ? 3 : Settings.getReadingDirection());
             mScaleMode.setSelection(Settings.getPageScaling());
             mStartPosition.setSelection(Settings.getStartPosition());
             mStartTransferTime.setProgress(Settings.getStartTransferTime());
@@ -1224,7 +1227,12 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
             }
 
             int screenRotation = mScreenRotation.getSelectedItemPosition();
-            int layoutMode = GalleryView.sanitizeLayoutMode(mReadingDirection.getSelectedItemPosition());
+            int readingDirectionPos = mReadingDirection.getSelectedItemPosition();
+            // 下拉框第4项（position 3）为“单手模式”：锁定为从左至右排版并开启翻页翻转
+            boolean oneHandMode = readingDirectionPos == 3;
+            int layoutMode = oneHandMode
+                    ? GalleryView.LAYOUT_LEFT_TO_RIGHT
+                    : GalleryView.sanitizeLayoutMode(readingDirectionPos);
             int scaleMode = GalleryView.sanitizeScaleMode(mScaleMode.getSelectedItemPosition());
             int startPosition = GalleryView.sanitizeStartPosition(mStartPosition.getSelectedItemPosition());
             boolean keepScreenOn = mKeepScreenOn.isChecked();
@@ -1244,6 +1252,7 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
 
             Settings.putScreenRotation(screenRotation);
             Settings.putReadingDirection(layoutMode);
+            Settings.putOneHandMode(oneHandMode);
             Settings.putPageScaling(scaleMode);
             Settings.putStartPosition(startPosition);
             Settings.putStartTransferTime(transferTime);
@@ -1281,6 +1290,7 @@ public class GalleryActivity extends EhActivity implements SeekBar.OnSeekBarChan
             }
             setRequestedOrientation(orientation);
             mGalleryView.setLayoutMode(layoutMode);
+            mGalleryView.setOneHandMode(oneHandMode);
             mGalleryView.setScaleMode(scaleMode);
             mGalleryView.setStartPosition(startPosition);
             if (keepScreenOn) {

--- a/app/src/main/java/com/hippo/lib/glgallery/GalleryView.java
+++ b/app/src/main/java/com/hippo/lib/glgallery/GalleryView.java
@@ -108,6 +108,7 @@ public final class GalleryView extends GLView implements GestureRecognizer.Liste
     private static final int METHOD_ON_ATTACH_TO_ROOT = 20;
     private static final int METHOD_SET_PAGER_INTERVAL = 21;
     private static final int METHOD_SET_SCROLL_INTERVAL = 22;
+    private static final int METHOD_SET_ONE_HAND_MODE = 23;
 
     private final Context mContext;
     private Adapter mAdapter;
@@ -130,6 +131,7 @@ public final class GalleryView extends GLView implements GestureRecognizer.Liste
     private final int mBackgroundColor;
     private int mPagerInterval;
     private int mScrollInterval;
+    private boolean mOneHandMode;
     private final int mPageMinHeight;
     private final int mPageInfoInterval;
     private final int mProgressColor;
@@ -418,6 +420,10 @@ public final class GalleryView extends GLView implements GestureRecognizer.Liste
         }
     }
 
+    private void setOneHandModeInternal(boolean oneHandMode) {
+        mOneHandMode = oneHandMode;
+    }
+
     @Override
     public void onAttachToRoot(GLRoot root) {
         super.onAttachToRoot(root);
@@ -563,6 +569,10 @@ public final class GalleryView extends GLView implements GestureRecognizer.Liste
 
     public void setScrollInterval(int interval) {
         postMethod(METHOD_SET_SCROLL_INTERVAL, interval);
+    }
+
+    public void setOneHandMode(boolean oneHandMode) {
+        postMethod(METHOD_SET_ONE_HAND_MODE, oneHandMode ? 1 : 0);
     }
 
     @Override
@@ -714,7 +724,12 @@ public final class GalleryView extends GLView implements GestureRecognizer.Liste
                 mListener.onTapMenuArea();
             }
         } else if (mLeftArea.contains((int) x, (int) y)) {
-            mLayoutManager.onPageLeft();
+            // 单手模式（锁定为从左至右排版）：原本翻上一页的左区域改为翻下一页
+            if (mOneHandMode) {
+                mLayoutManager.onPageRight();
+            } else {
+                mLayoutManager.onPageLeft();
+            }
         } else if (mRightArea.contains((int) x, (int) y)) {
             mLayoutManager.onPageRight();
         }
@@ -1006,6 +1021,9 @@ public final class GalleryView extends GLView implements GestureRecognizer.Liste
                     break;
                 case METHOD_SET_SCROLL_INTERVAL:
                     setScrollIntervalInternal((Integer) args[0]);
+                    break;
+                case METHOD_SET_ONE_HAND_MODE:
+                    setOneHandModeInternal((Integer) args[0] != 0);
                     break;
             }
         }

--- a/app/src/main/res/layout/dialog_gallery_menu.xml
+++ b/app/src/main/res/layout/dialog_gallery_menu.xml
@@ -69,7 +69,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_weight="2"
-                android:entries="@array/reading_direction_entries" />
+                android:entries="@array/reading_direction_entries_gallery" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -473,6 +473,7 @@
     <string name="settings_read_reading_direction_left_to_right">Von links nach rechts</string>
     <string name="settings_read_reading_direction_right_to_Left">Von rechts nach links</string>
     <string name="settings_read_reading_direction_top_to_bottom">Von oben nach unter</string>
+    <string name="settings_read_reading_direction_one_hand_mode">Einhandmodus</string>
     <string name="settings_read_page_scaling">Seitenskalierung</string>
     <string name="settings_read_page_scaling_actual_size">Originale Größe</string>
     <string name="settings_read_page_scaling_fit_to_width">Nach der Länge anpassen</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -546,6 +546,7 @@
     <string name="settings_read_reading_direction_left_to_right">Left to right</string>
     <string name="settings_read_reading_direction_right_to_Left">Right to left</string>
     <string name="settings_read_reading_direction_top_to_bottom">Top to bottom</string>
+    <string name="settings_read_reading_direction_one_hand_mode">One hand mode</string>
     <string name="settings_read_page_scaling">Page scaling</string>
     <string name="settings_read_page_scaling_actual_size">Actual size</string>
     <string name="settings_read_page_scaling_fit_to_width">Fit to width</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -526,6 +526,7 @@
     <string name="settings_read_reading_direction_left_to_right">Izquierda a derecha</string>
     <string name="settings_read_reading_direction_right_to_Left">Derecha a izquierda</string>
     <string name="settings_read_reading_direction_top_to_bottom">Arriba hacia abajo</string>
+    <string name="settings_read_reading_direction_one_hand_mode">Modo una mano</string>
     <string name="settings_read_page_scaling">Escala de página</string>
     <string name="settings_read_page_scaling_actual_size">Tamaño original</string>
     <string name="settings_read_page_scaling_fit_to_width">Ajustar a anchura</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -520,6 +520,7 @@
     <string name="settings_read_reading_direction_left_to_right">De gauche à droite</string>
     <string name="settings_read_reading_direction_right_to_Left">De droite à gauche</string>
     <string name="settings_read_reading_direction_top_to_bottom">De haut à fond</string>
+    <string name="settings_read_reading_direction_one_hand_mode">Mode une main</string>
     <string name="settings_read_page_scaling">Écaillage de page</string>
     <string name="settings_read_page_scaling_actual_size">Taille actuelle</string>
     <string name="settings_read_page_scaling_fit_to_width">S\'adapter à la largeur</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -528,6 +528,7 @@
     <string name="settings_read_reading_direction_left_to_right">左から右へ</string>
     <string name="settings_read_reading_direction_right_to_Left">右から左へ</string>
     <string name="settings_read_reading_direction_top_to_bottom">上から下へ</string>
+    <string name="settings_read_reading_direction_one_hand_mode">片手モード</string>
     <string name="settings_read_page_scaling">ページの拡大</string>
     <string name="settings_read_page_scaling_actual_size">元のサイズ</string>
     <string name="settings_read_page_scaling_fit_to_width">幅に合わせる</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -575,6 +575,7 @@
     <string name="settings_read_reading_direction_left_to_right">왼쪽에서 오른쪽으로</string>
     <string name="settings_read_reading_direction_right_to_Left">오른쪽에서 왼쪽으로</string>
     <string name="settings_read_reading_direction_top_to_bottom">위에서 아래로</string>
+    <string name="settings_read_reading_direction_one_hand_mode">한 손 모드</string>
     <string name="settings_read_page_scaling">페이지 표시</string>
     <string name="settings_read_page_scaling_actual_size">실제 크기</string>
     <string name="settings_read_page_scaling_fit_to_width">너비에 맞춤</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -564,6 +564,7 @@
     <string name="settings_read_reading_direction_left_to_right">ซ้าย -> ขวา</string>
     <string name="settings_read_reading_direction_right_to_Left">ขวา -> ซ้าย</string>
     <string name="settings_read_reading_direction_top_to_bottom">บน -> ล่าง</string>
+    <string name="settings_read_reading_direction_one_hand_mode">โหมดมือเดียว</string>
     <string name="settings_read_page_scaling">ขนาดของหน้า</string>
     <string name="settings_read_page_scaling_actual_size">เท่าขนาด</string>
     <string name="settings_read_page_scaling_fit_to_width">พอดีกับขนาดแนวกว้าง</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -555,6 +555,7 @@
     <string name="settings_read_reading_direction_left_to_right">从左至右</string>
     <string name="settings_read_reading_direction_right_to_Left">从右至左</string>
     <string name="settings_read_reading_direction_top_to_bottom">从上至下</string>
+    <string name="settings_read_reading_direction_one_hand_mode">单手模式</string>
     <string name="settings_read_page_scaling">页面缩放</string>
     <string name="settings_read_page_scaling_actual_size">原始尺寸</string>
     <string name="settings_read_page_scaling_fit_to_width">匹配宽度</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -608,6 +608,7 @@
     <string name="settings_read_reading_direction_left_to_right">從左至右</string>
     <string name="settings_read_reading_direction_right_to_Left">從右至左</string>
     <string name="settings_read_reading_direction_top_to_bottom">從上至下</string>
+    <string name="settings_read_reading_direction_one_hand_mode">單手模式</string>
     <string name="settings_read_page_scaling">頁面縮放</string>
     <string name="settings_read_page_scaling_actual_size">實際大小</string>
     <string name="settings_read_page_scaling_fit_to_width">符合寬度</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -555,6 +555,7 @@
     <string name="settings_read_reading_direction_left_to_right">由左到右</string>
     <string name="settings_read_reading_direction_right_to_Left">由右到左</string>
     <string name="settings_read_reading_direction_top_to_bottom">由上到下</string>
+    <string name="settings_read_reading_direction_one_hand_mode">單手模式</string>
     <string name="settings_read_page_scaling">頁面縮放</string>
     <string name="settings_read_page_scaling_actual_size">原始尺寸</string>
     <string name="settings_read_page_scaling_fit_to_width">貼齊寬度</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -251,6 +251,13 @@
         <item>@string/settings_read_reading_direction_top_to_bottom</item>
     </string-array>
 
+    <string-array name="reading_direction_entries_gallery">
+        <item>@string/settings_read_reading_direction_left_to_right</item>
+        <item>@string/settings_read_reading_direction_right_to_Left</item>
+        <item>@string/settings_read_reading_direction_top_to_bottom</item>
+        <item>@string/settings_read_reading_direction_one_hand_mode</item>
+    </string-array>
+
     <string-array name="reading_direction_entry_values" translatable="false">
         <item>0</item>
         <item>1</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -643,6 +643,7 @@
     <string name="settings_read_reading_direction_left_to_right">Left to right</string>
     <string name="settings_read_reading_direction_right_to_Left">Right to left</string>
     <string name="settings_read_reading_direction_top_to_bottom">Top to bottom</string>
+    <string name="settings_read_reading_direction_one_hand_mode">One hand mode</string>
     <string name="settings_read_page_scaling">Page scaling</string>
     <string name="settings_read_page_scaling_actual_size">Actual size</string>
     <string name="settings_read_page_scaling_fit_to_width">Fit to width</string>


### PR DESCRIPTION
想加这个很久了，求求了。之前躺床上手机来回左手换右手，翻页就很不方便。