### PR TITLE
feat: 画廊详情页高亮已订阅标签

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/data/userTag/UserTagList.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/data/userTag/UserTagList.java
@@ -48,4 +48,21 @@ public class UserTagList implements Parcelable {
     public int size(){
         return userTags.size();
     }
+
+    public UserTag findByTagName(String tagName) {
+        if (userTags == null || tagName == null) {
+            return null;
+        }
+        for (UserTag userTag : userTags) {
+            if (userTag != null && tagName.equalsIgnoreCase(userTag.tagName)) {
+                return userTag;
+            }
+        }
+        return null;
+    }
+
+    public boolean isWatched(String tagName) {
+        UserTag userTag = findByTagName(tagName);
+        return userTag != null && userTag.watched;
+    }
 }

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -50,6 +50,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
@@ -311,6 +312,7 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
     private GalleryListSceneDialog tagDialog;
 
     private boolean useNetWorkLoadThumb = false;
+    private boolean mUserTagListRequested;
 
     private Context mContext;
     private MainActivity activity;
@@ -1101,7 +1103,10 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
 
         ehTags = Settings.getShowTagTranslations() ? EhTagDatabase.getInstance(context) : null;
 
+        ensureUserTagList(context);
+        UserTagList userTagList = EhApplication.getUserTagList(context);
         int colorTag = AttrResources.getAttrColor(context, R.attr.tagBackgroundColor);
+        int colorWatched = getWatchedTagColor(context, colorTag);
         int colorName = AttrResources.getAttrColor(context, R.attr.tagGroupBackgroundColor);
         for (GalleryTagGroup tg : tagGroups) {
             LinearLayout ll = (LinearLayout) inflater.inflate(R.layout.gallery_tag_group, mTags, false);
@@ -1136,8 +1141,11 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
                 }
 
                 tag.setText(readableTag != null ? readableTag : tagStr);
-                tag.setBackgroundDrawable(new RoundSideRectDrawable(colorTag));
-                tag.setTag(R.id.tag, tg.groupName + ":" + tagStr);
+                String fullTag = tg.groupName + ":" + tagStr;
+                int backgroundColor = (userTagList != null && userTagList.isWatched(fullTag))
+                        ? colorWatched : colorTag;
+                tag.setBackgroundDrawable(new RoundSideRectDrawable(backgroundColor));
+                tag.setTag(R.id.tag, fullTag);
                 tag.setOnClickListener(this);
                 tag.setOnLongClickListener(this);
             }
@@ -1673,7 +1681,41 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
 
     @Override
     public void setTagList(UserTagList result) {
-        super.setTagList(result);
+        Context context = getEHContext();
+        if (context != null && result != null) {
+            EhApplication.saveUserTagList(context, result);
+        }
+        if (mGalleryDetail != null) {
+            bindTags(mGalleryDetail.tags);
+        }
+    }
+
+    private int getWatchedTagColor(Context context, int colorTag) {
+        int colorPrimary = ContextCompat.getColor(context, R.color.colorPrimary);
+        if (colorTag == colorPrimary) {
+            return ContextCompat.getColor(context, R.color.light_green_600);
+        }
+        return colorPrimary;
+    }
+
+    private void ensureUserTagList(Context context) {
+        if (!Settings.isLogin() || mUserTagListRequested || EhApplication.getUserTagList(context) != null) {
+            return;
+        }
+        MainActivity mainActivity = getActivity2();
+        if (mainActivity == null) {
+            return;
+        }
+        mUserTagListRequested = true;
+        EhRequest request = new EhRequest()
+                .setMethod(EhClient.METHOD_GET_WATCHED)
+                .setArgs(EhUrl.getMyTag())
+                .setCallback(new GetUserTagListListener(context, mainActivity.getStageId(), getTag()));
+        EhApplication.getEhClient(context).execute(request);
+    }
+
+    void onUserTagListLoadFailed() {
+        mUserTagListRequested = false;
     }
 
     @Override
@@ -2235,6 +2277,44 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
 
         @Override
         public void onCancel() {
+        }
+
+        @Override
+        public boolean isInstance(SceneFragment scene) {
+            return scene instanceof GalleryDetailScene;
+        }
+    }
+
+    private static class GetUserTagListListener extends EhCallback<GalleryDetailScene, UserTagList> {
+
+        public GetUserTagListListener(Context context, int stageId, String sceneTag) {
+            super(context, stageId, sceneTag);
+        }
+
+        @Override
+        public void onSuccess(UserTagList result) {
+            GalleryDetailScene scene = getScene();
+            if (scene != null) {
+                scene.setTagList(result);
+            } else if (result != null) {
+                EhApplication.saveUserTagList(getApplication(), result);
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            GalleryDetailScene scene = getScene();
+            if (scene != null) {
+                scene.onUserTagListLoadFailed();
+            }
+        }
+
+        @Override
+        public void onCancel() {
+            GalleryDetailScene scene = getScene();
+            if (scene != null) {
+                scene.onUserTagListLoadFailed();
+            }
         }
 
         @Override


### PR DESCRIPTION
## 改动
画廊详情页的标签如果已经在 My Tags 里 Watch，会用主题绿色高亮，方便和普通标签区分。

- 登录后缓存为空时拉一次 mytags，写入后重新绑定标签
- 只认 `watched == true`，Hidden / 排除标签不变色
- 只用 App 主题绿，不用官网 My Tags 的自定义颜色
- 浅色主题下默认标签已经是 `colorPrimary`，已订阅改用 `light_green_600`，避免看不出区别

关联 #2814

## 验证
- 登录后打开已订阅标签的画廊，对应标签变绿；未订阅标签保持原色
- 未登录不高亮、不请求 mytags
- Hidden 标签不变色
