### PR TITLE
feat: 已订阅标签长按改为取消订阅

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/data/userTag/UserTagList.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/data/userTag/UserTagList.java
@@ -48,4 +48,21 @@ public class UserTagList implements Parcelable {
     public int size(){
         return userTags.size();
     }
+
+    public UserTag findByTagName(String tagName) {
+        if (userTags == null || tagName == null) {
+            return null;
+        }
+        for (UserTag userTag : userTags) {
+            if (userTag != null && tagName.equalsIgnoreCase(userTag.tagName)) {
+                return userTag;
+            }
+        }
+        return null;
+    }
+
+    public boolean isWatched(String tagName) {
+        UserTag userTag = findByTagName(tagName);
+        return userTag != null && userTag.watched;
+    }
 }

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -50,6 +50,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
@@ -311,6 +312,7 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
     private GalleryListSceneDialog tagDialog;
 
     private boolean useNetWorkLoadThumb = false;
+    private boolean mUserTagListRequested;
 
     private Context mContext;
     private MainActivity activity;
@@ -1101,7 +1103,10 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
 
         ehTags = Settings.getShowTagTranslations() ? EhTagDatabase.getInstance(context) : null;
 
+        ensureUserTagList(context);
+        UserTagList userTagList = EhApplication.getUserTagList(context);
         int colorTag = AttrResources.getAttrColor(context, R.attr.tagBackgroundColor);
+        int colorWatched = getWatchedTagColor(context, colorTag);
         int colorName = AttrResources.getAttrColor(context, R.attr.tagGroupBackgroundColor);
         for (GalleryTagGroup tg : tagGroups) {
             LinearLayout ll = (LinearLayout) inflater.inflate(R.layout.gallery_tag_group, mTags, false);
@@ -1136,8 +1141,11 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
                 }
 
                 tag.setText(readableTag != null ? readableTag : tagStr);
-                tag.setBackgroundDrawable(new RoundSideRectDrawable(colorTag));
-                tag.setTag(R.id.tag, tg.groupName + ":" + tagStr);
+                String fullTag = tg.groupName + ":" + tagStr;
+                int backgroundColor = (userTagList != null && userTagList.isWatched(fullTag))
+                        ? colorWatched : colorTag;
+                tag.setBackgroundDrawable(new RoundSideRectDrawable(backgroundColor));
+                tag.setTag(R.id.tag, fullTag);
                 tag.setOnClickListener(this);
                 tag.setOnLongClickListener(this);
             }
@@ -1673,7 +1681,41 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
 
     @Override
     public void setTagList(UserTagList result) {
-        super.setTagList(result);
+        Context context = getEHContext();
+        if (context != null && result != null) {
+            EhApplication.saveUserTagList(context, result);
+        }
+        if (mGalleryDetail != null) {
+            bindTags(mGalleryDetail.tags);
+        }
+    }
+
+    private int getWatchedTagColor(Context context, int colorTag) {
+        int colorPrimary = ContextCompat.getColor(context, R.color.colorPrimary);
+        if (colorTag == colorPrimary) {
+            return ContextCompat.getColor(context, R.color.light_green_600);
+        }
+        return colorPrimary;
+    }
+
+    private void ensureUserTagList(Context context) {
+        if (!Settings.isLogin() || mUserTagListRequested || EhApplication.getUserTagList(context) != null) {
+            return;
+        }
+        MainActivity mainActivity = getActivity2();
+        if (mainActivity == null) {
+            return;
+        }
+        mUserTagListRequested = true;
+        EhRequest request = new EhRequest()
+                .setMethod(EhClient.METHOD_GET_WATCHED)
+                .setArgs(EhUrl.getMyTag())
+                .setCallback(new GetUserTagListListener(context, mainActivity.getStageId(), getTag()));
+        EhApplication.getEhClient(context).execute(request);
+    }
+
+    void onUserTagListLoadFailed() {
+        mUserTagListRequested = false;
     }
 
     @Override
@@ -2235,6 +2277,44 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
 
         @Override
         public void onCancel() {
+        }
+
+        @Override
+        public boolean isInstance(SceneFragment scene) {
+            return scene instanceof GalleryDetailScene;
+        }
+    }
+
+    private static class GetUserTagListListener extends EhCallback<GalleryDetailScene, UserTagList> {
+
+        public GetUserTagListListener(Context context, int stageId, String sceneTag) {
+            super(context, stageId, sceneTag);
+        }
+
+        @Override
+        public void onSuccess(UserTagList result) {
+            GalleryDetailScene scene = getScene();
+            if (scene != null) {
+                scene.setTagList(result);
+            } else if (result != null) {
+                EhApplication.saveUserTagList(getApplication(), result);
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            GalleryDetailScene scene = getScene();
+            if (scene != null) {
+                scene.onUserTagListLoadFailed();
+            }
+        }
+
+        @Override
+        public void onCancel() {
+            GalleryDetailScene scene = getScene();
+            if (scene != null) {
+                scene.onUserTagListLoadFailed();
+            }
         }
 
         @Override

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListSceneDialog.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListSceneDialog.kt
@@ -17,6 +17,7 @@ import com.hippo.ehviewer.client.EhRequest
 import com.hippo.ehviewer.client.EhTagDatabase
 import com.hippo.ehviewer.client.EhUrl
 import com.hippo.ehviewer.client.data.userTag.TagPushParam
+import com.hippo.ehviewer.client.data.userTag.UserTag
 import com.hippo.ehviewer.client.data.userTag.UserTagList
 import com.hippo.ehviewer.dao.Filter
 import com.hippo.ehviewer.ui.MainActivity
@@ -67,15 +68,22 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
             ) { _: DialogInterface?, _: Int -> copyTag(tagName) }
                 .show()
         } else {
+            val watchedTag = EhApplication.getUserTagList(context)?.findByTagName(tagName)
             builder.setNeutralButton(
                 R.string.copy_tag
             ) { _: DialogInterface?, _: Int -> copyTag(tagName) }
-                .setNegativeButton(
+            if (watchedTag != null && watchedTag.watched) {
+                builder.setNegativeButton(
+                    R.string.subscription_unwatched
+                ) { _: DialogInterface?, _: Int -> deleteWatchedTag(watchedTag) }
+            } else {
+                builder.setNegativeButton(
                     R.string.subscription_watched
                 ) { _: DialogInterface?, _: Int -> requestTag(tagName, true) }
-                .setPositiveButton(
-                    R.string.subscription_hidden
-                ) { _: DialogInterface?, _: Int -> requestTag(tagName, false) }
+            }
+            builder.setPositiveButton(
+                R.string.subscription_hidden
+            ) { _: DialogInterface?, _: Int -> requestTag(tagName, false) }
                 .show()
         }
     }
@@ -120,8 +128,10 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
         }
         val activity = baseScene.activity2 ?: return
 
+        val actionLabel =
+            if (tagState) R.string.subscription_watched else R.string.subscription_hidden
         val callback =
-            SubscriptionDetailListener(context, activity.stageId, baseScene.tag, tagState)
+            SubscriptionDetailListener(context, activity.stageId, baseScene.tag, actionLabel)
 
         val param = TagPushParam()
 
@@ -140,11 +150,27 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
         EhApplication.getEhClient(context).execute(mRequest)
     }
 
+    private fun deleteWatchedTag(userTag: UserTag) {
+        val url = EhUrl.getMyTag()
+        if (null == context) {
+            return
+        }
+        val activity = baseScene.activity2 ?: return
+        val callback = SubscriptionDetailListener(
+            context, activity.stageId, baseScene.tag, R.string.subscription_unwatched
+        )
+        val mRequest = EhRequest()
+            .setMethod(EhClient.METHOD_DELETE_WATCHED)
+            .setArgs(url, userTag)
+            .setCallback(callback)
+        EhApplication.getEhClient(context).execute(mRequest)
+    }
+
     private inner class SubscriptionDetailListener(
         context: Context,
         stageId: Int,
         sceneTag: String?,
-        private val tagState: Boolean
+        @StringRes private val actionLabel: Int
     ) :
         EhCallback<GalleryListScene?, UserTagList?>(context, stageId, sceneTag) {
         override fun isInstance(scene: SceneFragment): Boolean {
@@ -152,12 +178,14 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
         }
 
         override fun onSuccess(result: UserTagList?) {
+            if (result != null) {
+                EhApplication.saveUserTagList(context!!, result)
+            }
             baseScene.setTagList(result)
-            val state =
-                if (tagState) context!!.getString(R.string.subscription_watched) else context!!.getString(
-                    R.string.subscription_hidden
-                )
-            val msg = context.getString(R.string.subscription_success, state)
+            val msg = context!!.getString(
+                R.string.subscription_success,
+                context.getString(actionLabel)
+            )
             Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -878,6 +878,7 @@
 
     <!--  订阅服务  -->
     <string name="subscription_watched">Beobachtet</string>
+    <string name="subscription_unwatched">Nicht mehr beobachten</string>
     <string name="subscription_hidden">Versteckt</string>
     <string name="delete_subscription_title">Etikett entfernen</string>
     <string name="can_not_use_this_tag">Etiketten sind nicht verfügbar</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -834,6 +834,7 @@
     <string name="settings_eh_sign_out_restart">Automatically restarting for you, please wait</string>
     <!--  订阅服务  -->
     <string name="subscription_watched">Watched</string>
+    <string name="subscription_unwatched">Unsubscribe</string>
     <string name="subscription_hidden">Hidden</string>
     <string name="delete_subscription_title">Remove Tag</string>
     <string name="can_not_use_this_tag">Tags are not available</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -884,6 +884,7 @@
     <string name="category_all">Todo</string>
     <!--  订阅服务  -->
     <string name="subscription_watched">Visto</string>
+    <string name="subscription_unwatched">Dejar de seguir</string>
     <string name="subscription_hidden">Oculto</string>
     <string name="delete_subscription_title">Eliminar etiqueta</string>
     <string name="can_not_use_this_tag">Las etiquetas no están disponibles</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -861,6 +861,7 @@
     <string name="settings_eh_sign_out_restart">Redémarrage automatique en cours, veuillez patienter</string>
     <!--  订阅服务  -->
     <string name="subscription_watched">Surveillé</string>
+    <string name="subscription_unwatched">Ne plus surveiller</string>
     <string name="subscription_hidden">Masqué</string>
     <string name="delete_subscription_title">Supprimer le tag</string>
     <string name="can_not_use_this_tag">Les tags ne sont pas disponibles</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -801,6 +801,7 @@
     <string name="torrent_exist">ファイルは既に存在します: %s</string>
     <!--  订阅服务  -->
     <string name="subscription_watched">閲覧済み</string>
+    <string name="subscription_unwatched">ウォッチ解除</string>
     <string name="subscription_hidden">非表示</string>
     <string name="delete_subscription_title">タグを削除</string>
     <string name="can_not_use_this_tag">タグは利用できません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -874,6 +874,7 @@
 
     <!--  ??服?  -->
     <string name="subscription_watched">구독 중</string>
+    <string name="subscription_unwatched">구독 취소</string>
     <string name="subscription_hidden">구독 해제</string>
     <string name="delete_subscription_title">태그 삭제</string>
     <string name="can_not_use_this_tag">태그를 사용할 수 없음</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -860,6 +860,7 @@
     <string name="sort_by_fav_time">เวลาที่เพิ่มในรายการโปรด</string>
     <!--  订阅服务  -->
     <string name="subscription_watched">ดูแล้ว</string>
+    <string name="subscription_unwatched">เลิกติดตาม</string>
     <string name="subscription_hidden">ซ่อน</string>
     <string name="delete_subscription_title">ลบแท็ก</string>
     <string name="can_not_use_this_tag">แท็กไม่สามารถใช้งานได้</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -863,6 +863,7 @@
 
     <!--  订阅服务  -->
     <string name="subscription_watched">订阅</string>
+    <string name="subscription_unwatched">取消订阅</string>
     <string name="subscription_hidden">排除</string>
     <string name="delete_subscription_title">删除标签</string>
     <string name="can_not_use_this_tag">标签不可用</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -924,6 +924,7 @@
 
     <!--  订阅服务  -->
     <string name="subscription_watched">已觀看</string>
+    <string name="subscription_unwatched">取消訂閱</string>
     <string name="subscription_hidden">已隱藏</string>
     <string name="delete_subscription_title">移除標籤</string>
     <string name="can_not_use_this_tag">標籤不可用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -864,6 +864,7 @@
 
     <!--  訂閱服務  -->
     <string name="subscription_watched">訂閱</string>
+    <string name="subscription_unwatched">取消訂閱</string>
     <string name="subscription_hidden">排除</string>
     <string name="delete_subscription_title">刪除標籤</string>
     <string name="can_not_use_this_tag">標籤不可用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -955,6 +955,7 @@
 
     <!--  订阅服务  -->
     <string name="subscription_watched">Watched</string>
+    <string name="subscription_unwatched">Unsubscribe</string>
     <string name="subscription_hidden">Hidden</string>
     <string name="delete_subscription_title">Remove Tag</string>
     <string name="can_not_use_this_tag">Tags are not available</string>


### PR DESCRIPTION
## 改动
已订阅标签长按不再重复点「订阅」，改为「取消订阅」，走现有的 My Tags 删除接口（`METHOD_DELETE_WATCHED`）。未订阅仍是订阅 / 排除。

成功后写回 `userTagList` 并刷新详情页高亮。

依赖 #2824（请先合那个）。相对 #2824 只多了长按取消订阅和文案。

## 验证
- 已订阅标签长按出现「取消订阅」，取消后高亮消失
- 未订阅标签长按仍是「订阅」
- 排除入口不变
