### PR TITLE
feat: 支持订阅上传者

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/Settings.java
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.java
@@ -46,9 +46,12 @@ import com.hippo.lib.yorozuya.MathUtils;
 import com.hippo.lib.yorozuya.NumberUtils;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class Settings {
 
@@ -1529,5 +1532,58 @@ public class Settings {
 
     public static void putUpdateTime(long updateTime) {
         putLong(KEY_LAST_UPDATE_TIME,updateTime);
+    }
+
+    public static final String KEY_SUBSCRIBED_UPLOADERS = "subscribed_uploaders";
+
+    public static Set<String> getSubscribedUploaders() {
+        Set<String> stored = sSettingsPre.getStringSet(KEY_SUBSCRIBED_UPLOADERS, Collections.emptySet());
+        if (stored == null || stored.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(stored);
+    }
+
+    public static boolean isSubscribedUploader(String name) {
+        return name != null && getSubscribedUploaders().contains(name);
+    }
+
+    public static void addSubscribedUploader(String name) {
+        if (name == null || name.isEmpty()) {
+            return;
+        }
+        Set<String> set = new HashSet<>(getSubscribedUploaders());
+        if (!set.add(name)) {
+            return;
+        }
+        sSettingsPre.edit().putStringSet(KEY_SUBSCRIBED_UPLOADERS, set).apply();
+    }
+
+    public static void removeSubscribedUploader(String name) {
+        if (name == null || name.isEmpty()) {
+            return;
+        }
+        Set<String> set = new HashSet<>(getSubscribedUploaders());
+        if (!set.remove(name)) {
+            return;
+        }
+        sSettingsPre.edit().putStringSet(KEY_SUBSCRIBED_UPLOADERS, set).apply();
+    }
+
+    public static final String KEY_SUBSCRIPTION_FEED_MODE = "subscription_feed_mode";
+    public static final int SUBSCRIPTION_FEED_BOTH = 0;
+    public static final int SUBSCRIPTION_FEED_TAGS = 1;
+    public static final int SUBSCRIPTION_FEED_UPLOADERS = 2;
+
+    public static int getSubscriptionFeedMode() {
+        int mode = getInt(KEY_SUBSCRIPTION_FEED_MODE, SUBSCRIPTION_FEED_TAGS);
+        if (mode < SUBSCRIPTION_FEED_BOTH || mode > SUBSCRIPTION_FEED_UPLOADERS) {
+            return SUBSCRIPTION_FEED_TAGS;
+        }
+        return mode;
+    }
+
+    public static void setSubscriptionFeedMode(int mode) {
+        putInt(KEY_SUBSCRIPTION_FEED_MODE, mode);
     }
 }

--- a/app/src/main/java/com/hippo/ehviewer/client/EhEngine.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhEngine.java
@@ -36,6 +36,7 @@ import com.hippo.ehviewer.client.data.GalleryCommentList;
 import com.hippo.ehviewer.client.data.GalleryDetail;
 import com.hippo.ehviewer.client.data.GalleryInfo;
 import com.hippo.ehviewer.client.data.HomeDetail;
+import com.hippo.ehviewer.client.data.ListUrlBuilder;
 import com.hippo.ehviewer.client.data.TorrentInfo;
 import com.hippo.ehviewer.client.data.userTag.TagPushParam;
 import com.hippo.ehviewer.client.data.userTag.UserTag;
@@ -58,6 +59,7 @@ import com.hippo.ehviewer.client.parser.GalleryPageParser;
 import com.hippo.ehviewer.client.parser.GalleryTokenApiParser;
 import com.hippo.ehviewer.client.parser.GetEditCommentParser;
 import com.hippo.ehviewer.client.parser.MyTagLitParser;
+import com.hippo.ehviewer.client.parser.ParserUtils;
 import com.hippo.ehviewer.client.parser.ProfileParser;
 import com.hippo.ehviewer.client.parser.RateGalleryParser;
 import com.hippo.ehviewer.client.parser.SignInParser;
@@ -72,7 +74,10 @@ import com.hippo.lib.yorozuya.AssertUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -290,11 +295,147 @@ public class EhEngine {
 
         fillGalleryList(task, okHttpClient, result.galleryInfoList, url, true);
 
+        if (mode == ListUrlBuilder.MODE_SUBSCRIPTION) {
+            mergeSubscribedUploaderGalleries(task, okHttpClient, result, url);
+        }
+
         if (code == 200 && url.equals("https://exhentai.org/") && body.isEmpty()) {
             result.customErrorString = GetText.getString(R.string.error_igneous_wrong);
         }
 
         return result;
+    }
+
+    private static boolean isFirstSubscriptionPage(String url) {
+        if (url == null) {
+            return true;
+        }
+        return !url.contains("page=") && !url.contains("next=") && !url.contains("prev=")
+                && !url.contains("seek=");
+    }
+
+    private static long galleryPostedTime(GalleryInfo info) {
+        if (info == null) {
+            return 0L;
+        }
+        long posted = ParserUtils.parseDate(info.posted);
+        if (posted != 0L) {
+            return posted;
+        }
+        return info.gid;
+    }
+
+    private static void mergeSubscribedUploaderGalleries(@Nullable EhClient.Task task,
+            OkHttpClient okHttpClient, GalleryListParser.Result result, String url) throws Throwable {
+        int feedMode = Settings.getSubscriptionFeedMode();
+        if (feedMode == Settings.SUBSCRIPTION_FEED_TAGS) {
+            return;
+        }
+
+        Set<String> uploaders = Settings.getSubscribedUploaders();
+        if (uploaders.isEmpty()) {
+            if (feedMode == Settings.SUBSCRIPTION_FEED_UPLOADERS) {
+                result.galleryInfoList = new ArrayList<>();
+            }
+            return;
+        }
+
+        List<GalleryInfo> merged = result.galleryInfoList == null || result.galleryInfoList.isEmpty()
+                ? new ArrayList<GalleryInfo>()
+                : new ArrayList<>(result.galleryInfoList);
+        Set<Long> gids = new HashSet<>();
+        long lowTime = Long.MAX_VALUE;
+        long highTime = 0L;
+        for (GalleryInfo info : merged) {
+            gids.add(info.gid);
+            long posted = galleryPostedTime(info);
+            if (posted > 0L && posted < lowTime) {
+                lowTime = posted;
+            }
+            if (posted > highTime) {
+                highTime = posted;
+            }
+        }
+        if (lowTime == Long.MAX_VALUE) {
+            lowTime = 0L;
+        }
+        boolean firstPage = isFirstSubscriptionPage(url);
+        boolean uploadersOnly = feedMode == Settings.SUBSCRIPTION_FEED_UPLOADERS;
+        if (uploadersOnly) {
+            merged.clear();
+            gids.clear();
+            if (firstPage) {
+                lowTime = 0L;
+                highTime = 0L;
+            }
+        }
+
+        int maxPages = (uploadersOnly && firstPage) ? 1 : 5;
+        for (String name : uploaders) {
+            if (TextUtils.isEmpty(name)) {
+                continue;
+            }
+            addUploaderGalleriesInWindow(task, okHttpClient, name, merged, gids, lowTime, highTime,
+                    firstPage, maxPages);
+        }
+
+        Collections.sort(merged, (a, b) -> {
+            int cmp = Long.compare(galleryPostedTime(b), galleryPostedTime(a));
+            if (cmp != 0) {
+                return cmp;
+            }
+            return Long.compare(b.gid, a.gid);
+        });
+        result.galleryInfoList = merged;
+        if (!merged.isEmpty()) {
+            result.noWatchedTags = false;
+        }
+    }
+
+    private static void addUploaderGalleriesInWindow(@Nullable EhClient.Task task, OkHttpClient okHttpClient,
+            String name, List<GalleryInfo> merged, Set<Long> gids, long lowTime, long highTime,
+            boolean firstPage, int maxPages) throws Throwable {
+        for (int page = 0; page < maxPages; page++) {
+            ListUrlBuilder builder = new ListUrlBuilder();
+            builder.setMode(ListUrlBuilder.MODE_UPLOADER);
+            builder.setKeyword(name);
+            builder.setPageIndex(page);
+            GalleryListParser.Result extra;
+            try {
+                extra = getGalleryList(task, okHttpClient, builder.build(), ListUrlBuilder.MODE_UPLOADER);
+            } catch (Throwable e) {
+                ExceptionUtils.throwIfFatal(e);
+                if (e instanceof CancelledException) {
+                    throw e;
+                }
+                Log.d(TAG, "Failed to merge subscribed uploader: " + name, e);
+                return;
+            }
+            if (extra.galleryInfoList == null || extra.galleryInfoList.isEmpty()) {
+                return;
+            }
+            boolean reachedOlderThanWindow = false;
+            for (GalleryInfo info : extra.galleryInfoList) {
+                if (info == null) {
+                    continue;
+                }
+                long posted = galleryPostedTime(info);
+                if (posted < lowTime) {
+                    reachedOlderThanWindow = true;
+                    continue;
+                }
+                if (!firstPage && highTime > 0L && posted > highTime) {
+                    continue;
+                }
+                if (gids.add(info.gid)) {
+                    merged.add(info);
+                }
+            }
+            GalleryInfo last = extra.galleryInfoList.get(extra.galleryInfoList.size() - 1);
+            if (reachedOlderThanWindow || galleryPostedTime(last) < lowTime) {
+                return;
+            }
+        }
     }
 
     // At least, GalleryInfo contain valid gid and token

--- a/app/src/main/java/com/hippo/ehviewer/client/data/userTag/TagPushParam.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/data/userTag/TagPushParam.java
@@ -1,7 +1,7 @@
 package com.hippo.ehviewer.client.data.userTag;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 public class TagPushParam {
 
@@ -35,17 +35,21 @@ public class TagPushParam {
     }
 
     private String getEncodeTagName() {
-        if (tagNameNew == null) {
-            return "";
-        }
-        return URLEncoder.encode(tagNameNew, StandardCharsets.UTF_8);
+        return encode(tagNameNew);
     }
 
     private String getEncodeColorName() {
-        if (tagColorNew == null) {
-            return "";
-        }
-        return URLEncoder.encode(tagColorNew, StandardCharsets.UTF_8);
+        return encode(tagColorNew);
     }
 
+    private static String encode(String value) {
+        if (value == null) {
+            return "";
+        }
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return value;
+        }
+    }
 }

--- a/app/src/main/java/com/hippo/ehviewer/client/data/userTag/TagPushParam.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/data/userTag/TagPushParam.java
@@ -1,5 +1,8 @@
 package com.hippo.ehviewer.client.data.userTag;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 public class TagPushParam {
 
     public String userTagAction;
@@ -32,22 +35,17 @@ public class TagPushParam {
     }
 
     private String getEncodeTagName() {
-        String tagName = tagNameNew;
-
-        tagName.replace(":", "%3A");
-        tagName.replace(" ", "+");
-
-        return tagName;
+        if (tagNameNew == null) {
+            return "";
+        }
+        return URLEncoder.encode(tagNameNew, StandardCharsets.UTF_8);
     }
 
     private String getEncodeColorName() {
         if (tagColorNew == null) {
             return "";
         }
-        String tagColor = tagColorNew;
-        tagColor.replace("#", "%23");
-
-        return tagColor;
+        return URLEncoder.encode(tagColorNew, StandardCharsets.UTF_8);
     }
 
 }

--- a/app/src/main/java/com/hippo/ehviewer/client/parser/ParserUtils.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/parser/ParserUtils.java
@@ -20,6 +20,7 @@ import com.hippo.lib.yorozuya.NumberUtils;
 import com.hippo.lib.yorozuya.StringUtils;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -27,9 +28,31 @@ import java.util.Locale;
 public class ParserUtils {
 
     public static final DateFormat sDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US);
+    private static final DateFormat sDateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
     public static synchronized String formatDate(long time) {
         return sDateFormat.format(new Date(time));
+    }
+
+    public static synchronized long parseDate(String date) {
+        if (date == null || date.isEmpty()) {
+            return 0L;
+        }
+        try {
+            Date parsed = sDateFormat.parse(date);
+            if (parsed != null) {
+                return parsed.getTime();
+            }
+        } catch (ParseException ignored) {
+        }
+        try {
+            Date parsed = sDateOnlyFormat.parse(date);
+            if (parsed != null) {
+                return parsed.getTime();
+            }
+        } catch (ParseException ignored) {
+        }
+        return 0L;
     }
 
     public static String trim(String str) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -1615,6 +1615,40 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
         torrentDownloadController.showTorrentList(mContext, mGalleryDetail.torrentUrl, EhApplication.getOkHttpClient(mContext));
     }
 
+    private void showUploaderActionDialog() {
+        Context context = getEHContext();
+        String uploader = getUploader();
+        if (context == null || uploader == null) {
+            return;
+        }
+
+        new AlertDialog.Builder(context)
+                .setTitle(R.string.uploader_action_title)
+                .setItems(R.array.uploader_action_entries, (dialog, which) -> {
+                    if (which == 0) {
+                        subscribeUploader(uploader);
+                    } else if (which == 1) {
+                        showFilterUploaderDialog();
+                    }
+                })
+                .show();
+    }
+
+    private void subscribeUploader(String uploader) {
+        Context context = getEHContext();
+        if (context == null) {
+            return;
+        }
+        if (!Settings.isLogin()) {
+            showTip(R.string.settings_eh_identity_cookies_tourist, LENGTH_SHORT);
+            return;
+        }
+        if (tagDialog == null) {
+            tagDialog = new GalleryListSceneDialog(this);
+        }
+        tagDialog.subscribeUploader(uploader);
+    }
+
     private void showFilterUploaderDialog() {
         Context context = getEHContext();
         String uploader = getUploader();
@@ -1685,7 +1719,8 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
         }
 
         if (mUploader == v) {
-            showFilterUploaderDialog();
+            showUploaderActionDialog();
+            return true;
         } else if (mDownload == v) {
 //            GalleryInfo galleryInfo = getGalleryInfo();
 //            if (galleryInfo != null) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -1622,16 +1622,36 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
             return;
         }
 
+        boolean subscribed = Settings.isSubscribedUploader(uploader);
+        CharSequence[] items = new CharSequence[] {
+                getString(subscribed ? R.string.unsubscribe_the_uploader : R.string.subscribe_the_uploader),
+                getString(R.string.block_the_uploader)
+        };
         new AlertDialog.Builder(context)
                 .setTitle(R.string.uploader_action_title)
-                .setItems(R.array.uploader_action_entries, (dialog, which) -> {
+                .setItems(items, (dialog, which) -> {
                     if (which == 0) {
-                        subscribeUploader(uploader);
+                        if (subscribed) {
+                            unsubscribeUploader(uploader);
+                        } else {
+                            subscribeUploader(uploader);
+                        }
                     } else if (which == 1) {
                         showFilterUploaderDialog();
                     }
                 })
                 .show();
+    }
+
+    private void unsubscribeUploader(String uploader) {
+        Context context = getEHContext();
+        if (context == null) {
+            return;
+        }
+        if (tagDialog == null) {
+            tagDialog = new GalleryListSceneDialog(this);
+        }
+        tagDialog.unsubscribeUploader(uploader);
     }
 
     private void subscribeUploader(String uploader) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListScene.java
@@ -624,6 +624,58 @@ public final class GalleryListScene extends BaseScene
         }
         setNavCheckedItem(checkedItemId);
         mNavCheckedId = checkedItemId;
+        updateSubscriptionFeedFab();
+    }
+
+    private void updateSubscriptionFeedFab() {
+        if (mFabLayout == null || mUrlBuilder == null) {
+            return;
+        }
+        boolean subscription = mUrlBuilder.getMode() == ListUrlBuilder.MODE_SUBSCRIPTION;
+        FloatingActionButton fab = null;
+        int index = -1;
+        for (int i = 0; i < mFabLayout.getSecondaryFabCount(); i++) {
+            FloatingActionButton child = mFabLayout.getSecondaryFabAt(i);
+            if (child != null && child.getId() == R.id.subscription_feed_mode) {
+                fab = child;
+                index = i;
+                break;
+            }
+        }
+        if (index < 0 || fab == null) {
+            return;
+        }
+        mFabLayout.setSecondaryFabVisibilityAt(index, subscription);
+        if (!subscription) {
+            return;
+        }
+        int current = Settings.getSubscriptionFeedMode();
+        int next = (current + 1) % 3;
+        if (next == Settings.SUBSCRIPTION_FEED_TAGS) {
+            fab.setImageResource(R.drawable.ic_subscription_feed_tags);
+        } else if (next == Settings.SUBSCRIPTION_FEED_UPLOADERS) {
+            fab.setImageResource(R.drawable.ic_subscription_feed_uploaders);
+        } else {
+            fab.setImageResource(R.drawable.ic_subscription_feed_both);
+        }
+    }
+
+    private void cycleSubscriptionFeedMode() {
+        int next = (Settings.getSubscriptionFeedMode() + 1) % 3;
+        Settings.setSubscriptionFeedMode(next);
+        updateSubscriptionFeedFab();
+        int tip;
+        if (next == Settings.SUBSCRIPTION_FEED_TAGS) {
+            tip = R.string.subscription_feed_tags;
+        } else if (next == Settings.SUBSCRIPTION_FEED_UPLOADERS) {
+            tip = R.string.subscription_feed_uploaders;
+        } else {
+            tip = R.string.subscription_feed_both;
+        }
+        showTip(tip, LENGTH_SHORT);
+        if (mHelper != null) {
+            mHelper.refresh();
+        }
     }
 
     @NonNull
@@ -1462,6 +1514,12 @@ public final class GalleryListScene extends BaseScene
     @Override
     public void onClickSecondaryFab(FabLayout view, FloatingActionButton fab, int position) {
         if (null == mHelper) {
+            return;
+        }
+
+        if (fab.getId() == R.id.subscription_feed_mode) {
+            cycleSubscriptionFeedMode();
+            view.setExpanded(false);
             return;
         }
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListSceneDialog.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListSceneDialog.kt
@@ -112,6 +112,13 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
         Toast.makeText(context, R.string.gallery_tag_copy, Toast.LENGTH_LONG).show()
     }
 
+    fun subscribeUploader(uploader: String?) {
+        if (uploader.isNullOrEmpty()) {
+            return
+        }
+        requestTag("uploader:$uploader", true)
+    }
+
     private fun requestTag(tagName: String?, tagState: Boolean) {
         val url = EhUrl.getMyTag()
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListSceneDialog.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/list/GalleryListSceneDialog.kt
@@ -17,6 +17,7 @@ import com.hippo.ehviewer.client.EhRequest
 import com.hippo.ehviewer.client.EhTagDatabase
 import com.hippo.ehviewer.client.EhUrl
 import com.hippo.ehviewer.client.data.userTag.TagPushParam
+import com.hippo.ehviewer.client.data.userTag.UserTag
 import com.hippo.ehviewer.client.data.userTag.UserTagList
 import com.hippo.ehviewer.dao.Filter
 import com.hippo.ehviewer.ui.MainActivity
@@ -116,7 +117,43 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
         if (uploader.isNullOrEmpty()) {
             return
         }
+        Settings.addSubscribedUploader(uploader)
         requestTag("uploader:$uploader", true)
+    }
+
+    fun unsubscribeUploader(uploader: String?) {
+        if (uploader.isNullOrEmpty()) {
+            return
+        }
+        Settings.removeSubscribedUploader(uploader)
+        val userTag = findUploaderTag(uploader)
+        if (userTag != null) {
+            deleteWatchedTag(userTag)
+        } else {
+            showTip(R.string.unsubscribe_the_uploader_success, BaseScene.LENGTH_SHORT)
+        }
+    }
+
+    private fun findUploaderTag(uploader: String): UserTag? {
+        val ctx = context ?: return null
+        val list = EhApplication.getUserTagList(ctx) ?: return null
+        val tagName = "uploader:$uploader"
+        return list.userTags?.firstOrNull { it.tagName == tagName }
+    }
+
+    private fun deleteWatchedTag(userTag: UserTag) {
+        val ctx = context
+        val activity = baseScene.activity2
+        if (ctx == null || activity == null) {
+            showTip(R.string.unsubscribe_the_uploader_success, BaseScene.LENGTH_SHORT)
+            return
+        }
+        val callback = UnsubscribeListener(ctx, activity.stageId, baseScene.tag)
+        val request = EhRequest()
+            .setMethod(EhClient.METHOD_DELETE_WATCHED)
+            .setArgs(EhUrl.getMyTag(), userTag)
+            .setCallback(callback)
+        EhApplication.getEhClient(ctx).execute(request)
     }
 
     private fun requestTag(tagName: String?, tagState: Boolean) {
@@ -170,6 +207,28 @@ class GalleryListSceneDialog(val baseScene: BaseScene) {
 
         override fun onFailure(e: Exception) {
             Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
+        }
+
+        override fun onCancel() {
+        }
+    }
+
+    private inner class UnsubscribeListener(
+        context: Context,
+        stageId: Int,
+        sceneTag: String?
+    ) : EhCallback<GalleryListScene?, UserTagList?>(context, stageId, sceneTag) {
+        override fun isInstance(scene: SceneFragment): Boolean {
+            return false
+        }
+
+        override fun onSuccess(result: UserTagList?) {
+            baseScene.setTagList(result)
+            showTip(R.string.unsubscribe_the_uploader_success, BaseScene.LENGTH_SHORT)
+        }
+
+        override fun onFailure(e: Exception) {
+            showTip(R.string.unsubscribe_the_uploader_success, BaseScene.LENGTH_SHORT)
         }
 
         override fun onCancel() {

--- a/app/src/main/res/drawable/ic_subscription_feed_both.xml
+++ b/app/src/main/res/drawable/ic_subscription_feed_both.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Composite of Material Design Icons "person" + "local_offer" (Apache License 2.0)
+  https://github.com/google/material-design-icons
+-->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleX="0.86"
+        android:scaleY="0.86"
+        android:translateX="-0.8"
+        android:translateY="0.4">
+        <path
+            android:fillColor="?attr/iconColor"
+            android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2C20,15.34 14.67,14 12,14z"/>
+    </group>
+    <group
+        android:scaleX="0.5"
+        android:scaleY="0.5"
+        android:translateX="11.2"
+        android:translateY="10.8">
+        <path
+            android:fillColor="?attr/iconColor"
+            android:pathData="M21.41,11.58l-9,-9C12.05,2.22 11.55,2 11,2H4c-1.1,0 -2,0.9 -2,2v7c0,0.55 0.22,1.05 0.59,1.42l9,9c0.36,0.36 0.86,0.58 1.41,0.58 0.55,0 1.05,-0.22 1.41,-0.59l7,-7c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-0.55 -0.23,-1.06 -0.59,-1.42zM5.5,7C4.67,7 4,6.33 4,5.5S4.67,4 5.5,4 7,4.67 7,5.5 6.33,7 5.5,7z"/>
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_subscription_feed_tags.xml
+++ b/app/src/main/res/drawable/ic_subscription_feed_tags.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Material Design Icon "local_offer" (Apache License 2.0)
+  https://github.com/google/material-design-icons
+-->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/iconColor"
+        android:pathData="M21.41,11.58l-9,-9C12.05,2.22 11.55,2 11,2H4c-1.1,0 -2,0.9 -2,2v7c0,0.55 0.22,1.05 0.59,1.42l9,9c0.36,0.36 0.86,0.58 1.41,0.58 0.55,0 1.05,-0.22 1.41,-0.59l7,-7c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-0.55 -0.23,-1.06 -0.59,-1.42zM5.5,7C4.67,7 4,6.33 4,5.5S4.67,4 5.5,4 7,4.67 7,5.5 6.33,7 5.5,7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_subscription_feed_uploaders.xml
+++ b/app/src/main/res/drawable/ic_subscription_feed_uploaders.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Material Design Icon "person" (Apache License 2.0)
+  https://github.com/google/material-design-icons
+-->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/iconColor"
+        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2C20,15.34 14.67,14 12,14z"/>
+</vector>

--- a/app/src/main/res/layout/scene_gallery_list.xml
+++ b/app/src/main/res/layout/scene_gallery_list.xml
@@ -79,6 +79,14 @@
             app:backgroundTint="?attr/widgetColorThemeAccent"
             style="@style/Widget.Design.FloatingActionButton.Mini"/>
 
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/subscription_feed_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/ic_subscription_feed_uploaders"
+            app:backgroundTint="?attr/widgetColorThemeAccent"
+            android:visibility="gone"
+            style="@style/Widget.Design.FloatingActionButton.Mini"/>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:layout_width="wrap_content"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -302,6 +302,9 @@
     <string name="add_to_favorite_failure">Failed to add to favorites</string>
     <string name="remove_from_favorite_failure">Failed to remove from favorites</string>
     <string name="filter_the_uploader">Block the uploader \"%s\"?</string>
+    <string name="uploader_action_title">What would you like to do with this uploader?</string>
+    <string name="subscribe_the_uploader">Subscribe to this uploader</string>
+    <string name="block_the_uploader">Block this uploader</string>
     <string name="filter_the_tag">Block the tag \"%s\"?</string>
     <string name="filter_added">Blocker added</string>
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -304,6 +304,11 @@
     <string name="filter_the_uploader">Block the uploader \"%s\"?</string>
     <string name="uploader_action_title">What would you like to do with this uploader?</string>
     <string name="subscribe_the_uploader">Subscribe to this uploader</string>
+    <string name="unsubscribe_the_uploader">Unsubscribe from this uploader</string>
+    <string name="unsubscribe_the_uploader_success">Unsubscribed</string>
+    <string name="subscription_feed_tags">Tags only</string>
+    <string name="subscription_feed_uploaders">Uploaders only</string>
+    <string name="subscription_feed_both">Tags and uploaders</string>
     <string name="block_the_uploader">Block this uploader</string>
     <string name="filter_the_tag">Block the tag \"%s\"?</string>
     <string name="filter_added">Blocker added</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -275,6 +275,11 @@
     <string name="filter_the_uploader">屏蔽上传者“%s”？</string>
     <string name="uploader_action_title">你想对这个上传者做什么？</string>
     <string name="subscribe_the_uploader">订阅该上传者</string>
+    <string name="unsubscribe_the_uploader">取消订阅该上传者</string>
+    <string name="unsubscribe_the_uploader_success">已取消订阅</string>
+    <string name="subscription_feed_tags">只看订阅标签</string>
+    <string name="subscription_feed_uploaders">只看订阅上传者</string>
+    <string name="subscription_feed_both">同时显示订阅标签和上传者</string>
     <string name="block_the_uploader">屏蔽该上传者</string>
     <string name="filter_the_tag">屏蔽标签“%s”？</string>
     <string name="filter_added">已添加屏蔽项</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -273,6 +273,9 @@
     <string name="add_to_favorite_failure">添加收藏失败</string>
     <string name="remove_from_favorite_failure">移除收藏失败</string>
     <string name="filter_the_uploader">屏蔽上传者“%s”？</string>
+    <string name="uploader_action_title">你想对这个上传者做什么？</string>
+    <string name="subscribe_the_uploader">订阅该上传者</string>
+    <string name="block_the_uploader">屏蔽该上传者</string>
     <string name="filter_the_tag">屏蔽标签“%s”？</string>
     <string name="filter_added">已添加屏蔽项</string>
     <string name="copy_tag">复制</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -332,6 +332,9 @@
     <string name="add_to_favorite_failure">新增收藏失敗</string>
     <string name="remove_from_favorite_failure">移除收藏失敗</string>
     <string name="filter_the_uploader">封鎖上傳者“%s”？</string>
+    <string name="uploader_action_title">你想對這個上傳者做什麼？</string>
+    <string name="subscribe_the_uploader">訂閱該上傳者</string>
+    <string name="block_the_uploader">封鎖該上傳者</string>
     <string name="filter_the_tag">封鎖標籤“%s”？</string>
     <string name="filter_added">已新增封鎖項</string>
     <string name="copy_tag">複製</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -334,6 +334,11 @@
     <string name="filter_the_uploader">封鎖上傳者“%s”？</string>
     <string name="uploader_action_title">你想對這個上傳者做什麼？</string>
     <string name="subscribe_the_uploader">訂閱該上傳者</string>
+    <string name="unsubscribe_the_uploader">取消訂閱該上傳者</string>
+    <string name="unsubscribe_the_uploader_success">已取消訂閱</string>
+    <string name="subscription_feed_tags">只看訂閱標籤</string>
+    <string name="subscription_feed_uploaders">只看訂閱上傳者</string>
+    <string name="subscription_feed_both">同時顯示訂閱標籤和上傳者</string>
     <string name="block_the_uploader">封鎖該上傳者</string>
     <string name="filter_the_tag">封鎖標籤“%s”？</string>
     <string name="filter_added">已新增封鎖項</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -276,6 +276,9 @@
     <string name="add_to_favorite_failure">無法新增至收藏</string>
     <string name="remove_from_favorite_failure">無法從收藏中移除</string>
     <string name="filter_the_uploader">把上傳者 \"%s\" 加入遮蔽列表？</string>
+    <string name="uploader_action_title">你想對這個上傳者做什麼？</string>
+    <string name="subscribe_the_uploader">訂閱該上傳者</string>
+    <string name="block_the_uploader">遮蔽該上傳者</string>
     <string name="filter_the_tag">把標籤 \"%s\" 加入遮蔽列表？</string>
     <string name="filter_added">已經新增遮蔽項</string>
     <string name="copy_tag">複製</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -278,6 +278,11 @@
     <string name="filter_the_uploader">把上傳者 \"%s\" 加入遮蔽列表？</string>
     <string name="uploader_action_title">你想對這個上傳者做什麼？</string>
     <string name="subscribe_the_uploader">訂閱該上傳者</string>
+    <string name="unsubscribe_the_uploader">取消訂閱該上傳者</string>
+    <string name="unsubscribe_the_uploader_success">已取消訂閱</string>
+    <string name="subscription_feed_tags">只看訂閱標籤</string>
+    <string name="subscription_feed_uploaders">只看訂閱上傳者</string>
+    <string name="subscription_feed_both">同時顯示訂閱標籤和上傳者</string>
     <string name="block_the_uploader">遮蔽該上傳者</string>
     <string name="filter_the_tag">把標籤 \"%s\" 加入遮蔽列表？</string>
     <string name="filter_added">已經新增遮蔽項</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -326,6 +326,11 @@
         <item>@string/add_filter</item>
     </string-array>
 
+    <string-array name="uploader_action_entries">
+        <item>@string/subscribe_the_uploader</item>
+        <item>@string/block_the_uploader</item>
+    </string-array>
+
     <string-array name="app_language_entries">
         <item>@string/app_language_system</item>
         <item>@string/app_language_de</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -326,11 +326,6 @@
         <item>@string/add_filter</item>
     </string-array>
 
-    <string-array name="uploader_action_entries">
-        <item>@string/subscribe_the_uploader</item>
-        <item>@string/block_the_uploader</item>
-    </string-array>
-
     <string-array name="app_language_entries">
         <item>@string/app_language_system</item>
         <item>@string/app_language_de</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,6 +363,11 @@
     <string name="filter_the_uploader">Block the uploader \"%s\"?</string>
     <string name="uploader_action_title">What would you like to do with this uploader?</string>
     <string name="subscribe_the_uploader">Subscribe to this uploader</string>
+    <string name="unsubscribe_the_uploader">Unsubscribe from this uploader</string>
+    <string name="unsubscribe_the_uploader_success">Unsubscribed</string>
+    <string name="subscription_feed_tags">Tags only</string>
+    <string name="subscription_feed_uploaders">Uploaders only</string>
+    <string name="subscription_feed_both">Tags and uploaders</string>
     <string name="block_the_uploader">Block this uploader</string>
     <string name="filter_the_tag">Block the tag \"%s\"?</string>
     <string name="filter_added">Blocker added</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,6 +361,9 @@
     <string name="add_to_favorite_failure">Failed to add to favorites</string>
     <string name="remove_from_favorite_failure">Failed to remove from favorites</string>
     <string name="filter_the_uploader">Block the uploader \"%s\"?</string>
+    <string name="uploader_action_title">What would you like to do with this uploader?</string>
+    <string name="subscribe_the_uploader">Subscribe to this uploader</string>
+    <string name="block_the_uploader">Block this uploader</string>
     <string name="filter_the_tag">Block the tag \"%s\"?</string>
     <string name="filter_added">Blocker added</string>
     <string name="copy_tag">Copy</string>


### PR DESCRIPTION
## Summary
- 画廊详情长按上传者可订阅或屏蔽；已订阅时改为取消订阅。订阅名单存在本地，订阅栏按时间把上传者画廊和标签订阅混在一起。
- 订阅页悬浮球新增筛选按钮，默认只看订阅标签，可切换只看上传者 / 同时显示；图标表示点下去会变成哪种模式。
- 修复 My Tags 提交时的假 URL 编码，并改用兼容 minSdk 23 的 `URLEncoder.encode(String, String)`，避免低版本崩溃。

## Test plan
- [ ] 长按上传者：未订阅显示「订阅 / 屏蔽」，已订阅显示「取消订阅 / 屏蔽」；单击上传者仍进入其列表
- [ ] 订阅后切到「同时显示」，下拉刷新订阅栏，上传者新作与标签订阅按时间交错，不会整页挤在一起
- [ ] 取消订阅后再刷新，该上传者不再出现在混流里
- [ ] 订阅页点 + ，新按钮默认下一步为「只看上传者」；三种模式图标与提示文案一致；首页/热门不出现该按钮
- [ ] 未登录时订阅会提示登录；屏蔽仍走本地 Filter
